### PR TITLE
Enhancement: Integration of `StoriesResolvedApi` for automatic relation resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,26 @@ final class PurgeVarnishHandler implements WebhookHandlerInterface
 }
 ```
 
+#### Auto resolve relations
+
+
+If you want to update relations automatically, you can enable this with the following configuration:
+
+```yaml
+# config/packages/storyblok.yaml
+storyblok:
+    # ...
+    auto_resolve_relations: true
+```
+
+This will replace `StoriesApi` to `StoriesResolvedApi`. The `StoriesResolvedApi` will automatically resolve relations.
+
+> [!WARNING]
+> Maximum 50 different relations can be resolved in one request. See
+> [Storyblok docs](https://www.storyblok.com/docs/api/content-delivery/v2/stories/retrieve-a-single-story)
+> for more information
+
+
 #### Best Practices
 
 - **Handle Only Necessary Events**: Use the `supports` method to filter only the Webhook events your handler should

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=8.3",
     "oskarstark/enum-helper": "^1.5",
     "psr/log": "^3.0",
-    "storyblok/php-content-api-client": "^0.1.0",
+    "storyblok/php-content-api-client": "^0.2.0",
     "symfony/config": "^6.0 || ^7.0",
     "symfony/dependency-injection": "^6.0 || ^7.0",
     "symfony/framework-bundle": "^6.0 || ^7.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -47,6 +47,9 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('published')
                     ->cannotBeEmpty()
                 ->end()
+                ->booleanNode('auto_resolve_stories')
+                    ->defaultValue(false)
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -47,7 +47,7 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('published')
                     ->cannotBeEmpty()
                 ->end()
-                ->booleanNode('auto_resolve_stories')
+                ->booleanNode('auto_resolve_relations')
                     ->defaultValue(false)
                 ->end()
             ->end()

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -15,6 +15,8 @@ namespace Storyblok\Bundle\DependencyInjection;
 
 use Storyblok\Api\AssetsApi;
 use Storyblok\Api\AssetsApiInterface;
+use Storyblok\Api\Resolver\ResolverInterface;
+use Storyblok\Api\Resolver\StoryResolver;
 use Storyblok\Api\StoriesApi;
 use Storyblok\Api\StoriesApiInterface;
 use Storyblok\Api\StoriesResolvedApi;
@@ -30,9 +32,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpClient\TraceableHttpClient;
-use Storyblok\Api\Resolver\ResolverInterface;
-use Storyblok\Api\Resolver\StoryResolver;
-
 
 final class StoryblokExtension extends Extension
 {

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -71,7 +71,7 @@ final class StoryblokExtension extends Extension
             ));
         }
 
-        if (true === $config['auto_resolve_stories']) {
+        if (true === $config['auto_resolve_relations']) {
             $storiesApi = new Definition(StoriesApi::class, [
                 '$client' => $container->getDefinition(StoryblokClient::class),
                 '$version' => $container->getParameter('storyblok_api.version'),

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -40,13 +40,13 @@ final class ConfigurationTest extends TestCase
             ['token' => $token],
             ['webhook_secret' => $secret],
             ['version' => $version],
-            ['auto_resolve_stories' => $autoResolve],
+            ['auto_resolve_relations' => $autoResolve],
         ], [
             'base_uri' => $url,
             'token' => $token,
             'webhook_secret' => $secret,
             'version' => $version,
-            'auto_resolve_stories' => $autoResolve,
+            'auto_resolve_relations' => $autoResolve,
         ]);
     }
 
@@ -67,7 +67,7 @@ final class ConfigurationTest extends TestCase
             'token' => $token,
             'webhook_secret' => null,
             'version' => 'published',
-            'auto_resolve_stories' => false,
+            'auto_resolve_relations' => false,
         ]);
     }
 

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -33,17 +33,20 @@ final class ConfigurationTest extends TestCase
         $token = $faker->uuid();
         $secret = $faker->uuid();
         $version = $faker->randomElement(['draft', 'published']);
+        $autoResolve = $faker->boolean();
 
         self::assertProcessedConfigurationEquals([
             ['base_uri' => $url],
             ['token' => $token],
             ['webhook_secret' => $secret],
             ['version' => $version],
+            ['auto_resolve_stories' => $autoResolve],
         ], [
             'base_uri' => $url,
             'token' => $token,
             'webhook_secret' => $secret,
             'version' => $version,
+            'auto_resolve_stories' => $autoResolve,
         ]);
     }
 
@@ -64,6 +67,7 @@ final class ConfigurationTest extends TestCase
             'token' => $token,
             'webhook_secret' => null,
             'version' => 'published',
+            'auto_resolve_stories' => false,
         ]);
     }
 

--- a/tests/Unit/DependencyInjection/StoryblokExtensionTest.php
+++ b/tests/Unit/DependencyInjection/StoryblokExtensionTest.php
@@ -16,6 +16,8 @@ namespace Storyblok\Bundle\Tests\Unit\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Storyblok\Api\AssetsApi;
 use Storyblok\Api\AssetsApiInterface;
+use Storyblok\Api\Resolver\ResolverInterface;
+use Storyblok\Api\StoriesResolvedApi;
 use Storyblok\Api\StoryblokClientInterface;
 use Storyblok\Bundle\DataCollector\StoryblokCollector;
 use Storyblok\Bundle\DependencyInjection\StoryblokExtension;
@@ -166,5 +168,31 @@ final class StoryblokExtensionTest extends TestCase
         self::assertTrue($builder->hasDefinition(AssetsApi::class));
 
         self::assertSame($token, $builder->getParameter('storyblok_api.assets_token'));
+    }
+
+    /**
+     * @test
+     */
+    public function loadWithAutoResolveStoriesTrue(): void
+    {
+        $faker = self::faker();
+
+        $extension = new StoryblokExtension();
+        $builder = new ContainerBuilder();
+        $builder->setParameter('kernel.debug', true);
+
+        $config = [
+            ['base_uri' => $faker->url()],
+            ['token' => $faker->uuid()],
+            ['auto_resolve_stories' => true],
+        ];
+
+        $extension->load(
+            $config,
+            $builder,
+        );
+
+        self::assertTrue($builder->hasAlias(ResolverInterface::class));
+        self::assertTrue($builder->hasDefinition(StoriesResolvedApi::class));
     }
 }

--- a/tests/Unit/DependencyInjection/StoryblokExtensionTest.php
+++ b/tests/Unit/DependencyInjection/StoryblokExtensionTest.php
@@ -184,7 +184,7 @@ final class StoryblokExtensionTest extends TestCase
         $config = [
             ['base_uri' => $faker->url()],
             ['token' => $faker->uuid()],
-            ['auto_resolve_stories' => true],
+            ['auto_resolve_relations' => true],
         ];
 
         $extension->load(


### PR DESCRIPTION
This PR integrates the StoriesResolvedApi introduced in https://github.com/storyblok/php-content-api-client/pull/8 into the Symfony bundle. With this integration, the bundle now offers the option to automatically resolve relations within the Stories API.

**Configuration:**

```yaml
# config/packages/storyblok.yaml
storyblok:
    # ...
    auto_resolve_relations: true
```

**Key Changes:**
- `auto_resolve_relations` flag: A new configuration option is added to control whether relations are automatically resolved. By default, this flag is set to `false`, meaning the original `StoriesApi` is used.
- When `auto_resolve_relations` is set to `true`, the `StoriesResolvedApi` is used instead, allowing for automatic relation resolution.

How It Works:
- If the flag is enabled, the `StoriesResolvedApi` is used, which internally resolves relations like article.author and article.category without additional effort from the user.
- This change makes it easier for users to work with related content, automating the resolution process while keeping the flexibility to disable it if needed.

**Default Behavior**:
- The default behavior of the bundle remains unchanged with the `auto_resolve_relations` flag set to false.
