### PR TITLE
Prevent `assets` directory from being exported on git release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.neon export-ignore
 *.dist export-ignore
 tests export-ignore
+assets export-ignore


### PR DESCRIPTION
The image should not be inside the release, because it increases the package size and its not relevant when using this package