### PR TITLE
Introduce `#[AsBlock]` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ final readonly class SampleBlock
 
 | Parameter       | Type    | Required? | Description |
 |----------------|--------|-----------|-------------|
-| `technicalName` | `string` | No | The block name used in Storyblok. Defaults to the class name converted to camelCase. |
+| `technicalName` | `string` | No | The block name used in Storyblok. Defaults to the class name converted to snake_case. |
 | `template`      | `string` | No | The Twig template for rendering the block. Defaults to `blocks/{technical_name}.html.twig`. |
 
 ### Customizing the Default Template Path

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ This will replace `StoriesApi` to `StoriesResolvedApi`. The `StoriesResolvedApi`
 
 ## Block Registration with `#[AsBlock]`
 
-Starting with this release, you can register Storyblok blocks using the `#[AsBlock]` attribute.
+You can register Storyblok blocks using the `#[AsBlock]` attribute.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ This will replace `StoriesApi` to `StoriesResolvedApi`. The `StoriesResolvedApi`
 
 You can register Storyblok blocks using the `#[AsBlock]` attribute.
 
+The `name` and `template` parameters are optional, you will find their defaults in the following section.
+
 ### Usage
 
 To define a block, use the attribute on a class:
@@ -215,14 +217,14 @@ final readonly class SampleBlock
 
 ### Attribute Parameters
 
-| Parameter       | Type    | Required? | Description |
-|----------------|--------|-----------|-------------|
-| `technicalName` | `string` | No | The block name used in Storyblok. Defaults to the class name converted to snake_case. |
-| `template`      | `string` | No | The Twig template for rendering the block. Defaults to `blocks/{technical_name}.html.twig`. |
+| Parameter  | Type    | Required? | Description |
+|------------|--------|-----------|-------------|
+| `name`     | `string` | No | The block name used in Storyblok. Defaults to the class name converted to snake_case. |
+| `template` | `string` | No | The Twig template for rendering the block. Defaults to `blocks/{name}.html.twig`. |
 
 ### Customizing the Default Template Path
 
-If you prefer a different template structure, configure it in `storyblok.yaml`:
+You can change the default template path structure by configuring it in `storyblok.yaml`:
 
 ```yaml
 # config/packages/storyblok.yaml

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ To define a block, use the attribute on a class:
 use Storyblok\Bundle\Block\Attribute\AsBlock;
 use Webmozart\Assert\Assert;
 
-#[AsBlock(technicalName: 'sample', template: 'custom_blocks/sample.html.twig')]
+#[AsBlock(name: 'sample', template: 'custom_blocks/sample.html.twig')]
 final readonly class SampleBlock
 {
     public string $title;

--- a/README.md
+++ b/README.md
@@ -184,6 +184,65 @@ This will replace `StoriesApi` to `StoriesResolvedApi`. The `StoriesResolvedApi`
 > [Storyblok docs](https://www.storyblok.com/docs/api/content-delivery/v2/stories/retrieve-a-single-story)
 > for more information
 
+## Block Registration with `#[AsBlock]`
+
+Starting with this release, you can register Storyblok blocks using the `#[AsBlock]` attribute.
+
+### Usage
+
+To define a block, use the attribute on a class:
+
+```php
+use Storyblok\Bundle\Block\Attribute\AsBlock;
+use Webmozart\Assert\Assert;
+
+#[AsBlock(technicalName: 'sample', template: 'custom_blocks/sample.html.twig')]
+final readonly class SampleBlock
+{
+    public string $title;
+    public string $description;
+
+    public function __construct(array $values)
+    {
+        Assert::keyExists($values, 'title');
+        $this->title = $values['title'];
+
+        Assert::keyExists($values, 'description');
+        $this->description = $values['description'];
+    }
+}
+```
+
+### Attribute Parameters
+
+| Parameter       | Type    | Required? | Description |
+|----------------|--------|-----------|-------------|
+| `technicalName` | `string` | No | The block name used in Storyblok. Defaults to the class name converted to camelCase. |
+| `template`      | `string` | No | The Twig template for rendering the block. Defaults to `blocks/{technical_name}.html.twig`. |
+
+### Customizing the Default Template Path
+
+If you prefer a different template structure, configure it in `storyblok.yaml`:
+
+```yaml
+# config/packages/storyblok.yaml
+storyblok:
+    blocks_template_path: 'my/custom/path'
+```
+
+### Rendering Blocks in Twig
+
+A new `render_block` Twig filter allows easy rendering of Storyblok blocks:
+
+```twig
+{% for block in page.body %}
+    {% if block is not null %}
+        {{ block|render_block }}
+    {% endif %}
+{% endfor %}
+```
+
+This ensures dynamic rendering of Storyblok components with minimal effort.
 
 #### Best Practices
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
     "symfony/http-client": "^6.0 || ^7.0",
     "symfony/http-kernel": "^6.0 || ^7.0",
     "symfony/monolog-bundle": "^3.10",
+    "symfony/string": "^6.0 || ^7.0",
     "thecodingmachine/safe": "^2.0 || ^3.0",
+    "twig/twig": "^3.20",
     "webmozart/assert": "^1.11"
   },
   "require-dev": {

--- a/config/services.php
+++ b/config/services.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Storyblok\Api\StoryblokClientInterface;
-use Storyblok\Bundle\Block\BlockCollection;
+use Storyblok\Bundle\Block\BlockRegistry;
 use Storyblok\Bundle\Block\Renderer\BlockRenderer;
 use Storyblok\Bundle\Block\Renderer\RendererInterface;
 use Storyblok\Bundle\Controller\WebhookController;
@@ -100,7 +100,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(BlockRenderer::class)
         ->alias(RendererInterface::class, BlockRenderer::class)
 
-        ->set(BlockCollection::class)
+        ->set(BlockRegistry::class)
 
         ->set(BlockExtension::class)
         ->tag('twig.extension')

--- a/config/services.php
+++ b/config/services.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Storyblok\Api\StoryblokClientInterface;
+use Storyblok\Bundle\Block\BlockCollection;
+use Storyblok\Bundle\Block\Renderer\BlockRenderer;
+use Storyblok\Bundle\Block\Renderer\RendererInterface;
 use Storyblok\Bundle\Controller\WebhookController;
 use Storyblok\Bundle\DataCollector\StoryblokCollector;
 use Storyblok\Bundle\Listener\UpdateProfilerListener;
@@ -92,5 +95,10 @@ return static function (ContainerConfigurator $container): void {
                 'method' => 'onKernelResponse',
                 'priority' => -255,
             ])
+
+        ->set(BlockRenderer::class)
+        ->alias(RendererInterface::class, BlockRenderer::class)
+
+        ->set(BlockCollection::class)
     ;
 };

--- a/config/services.php
+++ b/config/services.php
@@ -20,6 +20,7 @@ use Storyblok\Api\StoriesApiInterface;
 use Storyblok\Api\StoryblokClient;
 use Storyblok\Api\TagsApi;
 use Storyblok\Api\TagsApiInterface;
+use Storyblok\Bundle\Twig\BlockExtension;
 use Storyblok\Bundle\Webhook\WebhookEventHandlerChain;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\ScopingHttpClient;
@@ -100,5 +101,8 @@ return static function (ContainerConfigurator $container): void {
         ->alias(RendererInterface::class, BlockRenderer::class)
 
         ->set(BlockCollection::class)
+
+        ->set(BlockExtension::class)
+        ->tag('twig.extension')
     ;
 };

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,6 +19,12 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
+			message: '#^Parameter \#2 \$configurator of method Symfony\\Component\\DependencyInjection\\ContainerBuilder\:\:registerAttributeForAutoconfiguration\(\) expects callable\(Symfony\\Component\\DependencyInjection\\ChildDefinition, Storyblok\\Bundle\\Block\\Attribute\\AsBlock, Reflector\)\: void, Closure\(Symfony\\Component\\DependencyInjection\\ChildDefinition, Storyblok\\Bundle\\Block\\Attribute\\AsBlock, ReflectionClass\)\: void given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DependencyInjection/StoryblokExtension.php
+
+		-
 			message: '#^Parameter \#2 \$className of class Storyblok\\Bundle\\Block\\BlockDefinition constructor expects class\-string, string given\.$#'
 			identifier: argument.type
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,31 +1,49 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Storyblok\\\\Bundle\\\\DataCollector\\\\StoryblokCollector\\:\\:collectOnClient\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Call to static method Webmozart\\Assert\\Assert\:\:stringNotEmpty\(\) with class\-string will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: src/Block/BlockDefinition.php
+
+		-
+			message: '#^Method Storyblok\\Bundle\\DataCollector\\StoryblokCollector\:\:collectOnClient\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/DataCollector/StoryblokCollector.php
 
 		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
+			message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\:\:children\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Method Storyblok\\\\Bundle\\\\Tests\\\\Unit\\\\Listener\\\\UpdateProfilerListenerTest\\:\\:createKernel\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Parameter \#2 \$className of class Storyblok\\Bundle\\Block\\BlockDefinition constructor expects class\-string, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Unit/Block/BlockDefinitionTest.php
+
+		-
+			message: '#^Method Storyblok\\Bundle\\Tests\\Unit\\Listener\\UpdateProfilerListenerTest\:\:createKernel\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: tests/Unit/Listener/UpdateProfilerListenerTest.php
 
 		-
-			message: "#^Method Storyblok\\\\Bundle\\\\Tests\\\\Util\\\\TestKernel\\:\\:create\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Storyblok\\Bundle\\Tests\\Util\\TestKernel\:\:create\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: tests/Util/TestKernel.php
 
 		-
-			message: "#^Method Storyblok\\\\Bundle\\\\Tests\\\\Util\\\\TestKernel\\:\\:debug\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Storyblok\\Bundle\\Tests\\Util\\TestKernel\:\:debug\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: tests/Util/TestKernel.php
 
 		-
-			message: "#^Method Storyblok\\\\Bundle\\\\Tests\\\\Util\\\\TestKernel\\:\\:environment\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Storyblok\\Bundle\\Tests\\Util\\TestKernel\:\:environment\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: tests/Util/TestKernel.php

--- a/src/Block/Attribute/AsBlock.php
+++ b/src/Block/Attribute/AsBlock.php
@@ -17,7 +17,7 @@ namespace Storyblok\Bundle\Block\Attribute;
 final readonly class AsBlock
 {
     public function __construct(
-        public ?string $technicalName = null,
+        public ?string $name = null,
         public ?string $template = null,
     ) {
     }

--- a/src/Block/Attribute/AsBlock.php
+++ b/src/Block/Attribute/AsBlock.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Block\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final readonly class AsBlock
+{
+    public function __construct(
+        public ?string $technicalName = null,
+        public ?string $template = null,
+    ) {
+    }
+}

--- a/src/Block/BlockCollection.php
+++ b/src/Block/BlockCollection.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Block;
+
+use Storyblok\Bundle\Block\Exception\BlockNotFoundException;
+
+/**
+ * @implements \IteratorAggregate<int, BlockDefinition>
+ */
+final class BlockCollection implements \Countable, \IteratorAggregate
+{
+    /**
+     * @var array<class-string, BlockDefinition>
+     */
+    private array $blocks = [];
+
+    /**
+     * @param list<BlockDefinition|array{
+     *     fqcn: class-string,
+     *     technicalName: non-empty-string,
+     *     template: non-empty-string,
+     * }> $blocks
+     */
+    public function __construct(array $blocks = [])
+    {
+        foreach ($blocks as $block) {
+            $this->add($block);
+        }
+    }
+
+    /**
+     * @param array<string, mixed>|BlockDefinition $definition
+     */
+    public function add(array|BlockDefinition $definition): void
+    {
+        if (\is_array($definition)) {
+            $definition = BlockDefinition::fromArray($definition);
+        }
+
+        $this->blocks[$definition->className] = $definition;
+    }
+
+    /**
+     * @param class-string $fqcn
+     */
+    public function get(string $fqcn): BlockDefinition
+    {
+        if (!\array_key_exists($fqcn, $this->blocks)) {
+            throw new BlockNotFoundException(\sprintf('Block "%s" not found.', $fqcn));
+        }
+
+        return $this->blocks[$fqcn];
+    }
+
+    public function byTechnicalName(string $name): BlockDefinition
+    {
+        $definitions = \array_values(\array_filter(
+            $this->blocks,
+            static fn (BlockDefinition $definition) => $definition->technicalName === $name,
+        ));
+
+        if (0 === \count($definitions)) {
+            throw new BlockNotFoundException(\sprintf('Block "%s" not found.', $name));
+        }
+
+        return $definitions[0];
+    }
+
+    /**
+     * @return \ArrayIterator<int, BlockDefinition>
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator(\array_values($this->blocks));
+    }
+
+    public function count(): int
+    {
+        return \count($this->blocks);
+    }
+}

--- a/src/Block/BlockCollection.php
+++ b/src/Block/BlockCollection.php
@@ -28,7 +28,7 @@ final class BlockCollection implements \Countable, \IteratorAggregate
     /**
      * @param list<BlockDefinition|array{
      *     fqcn: class-string,
-     *     technicalName: non-empty-string,
+     *     name: non-empty-string,
      *     template: non-empty-string,
      * }> $blocks
      */
@@ -63,11 +63,11 @@ final class BlockCollection implements \Countable, \IteratorAggregate
         return $this->blocks[$fqcn];
     }
 
-    public function byTechnicalName(string $name): BlockDefinition
+    public function byName(string $name): BlockDefinition
     {
         $definitions = \array_values(\array_filter(
             $this->blocks,
-            static fn (BlockDefinition $definition) => $definition->technicalName === $name,
+            static fn (BlockDefinition $definition) => $definition->name === $name,
         ));
 
         if (0 === \count($definitions)) {

--- a/src/Block/BlockDefinition.php
+++ b/src/Block/BlockDefinition.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Block;
+
+use Webmozart\Assert\Assert;
+
+final readonly class BlockDefinition
+{
+    /**
+     * @param class-string $className
+     */
+    public function __construct(
+        public string $technicalName,
+        public string $className,
+        public string $template,
+    ) {
+        Assert::stringNotEmpty($technicalName);
+        Assert::notWhitespaceOnly($technicalName);
+
+        Assert::stringNotEmpty($className);
+        Assert::notWhitespaceOnly($className);
+        Assert::classExists($className);
+
+        Assert::stringNotEmpty($template);
+        Assert::notWhitespaceOnly($template);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public static function fromArray(array $values): self
+    {
+        Assert::keyExists($values, 'className');
+        Assert::string($values['className']);
+        Assert::classExists($values['className']);
+
+        Assert::keyExists($values, 'technicalName');
+        Assert::string($values['technicalName']);
+
+        Assert::keyExists($values, 'template');
+        Assert::string($values['template']);
+
+        return new self(
+            technicalName: $values['technicalName'],
+            className: $values['className'],
+            template: $values['template'],
+        );
+    }
+}

--- a/src/Block/BlockDefinition.php
+++ b/src/Block/BlockDefinition.php
@@ -21,12 +21,12 @@ final readonly class BlockDefinition
      * @param class-string $className
      */
     public function __construct(
-        public string $technicalName,
+        public string $name,
         public string $className,
         public string $template,
     ) {
-        Assert::stringNotEmpty($technicalName);
-        Assert::notWhitespaceOnly($technicalName);
+        Assert::stringNotEmpty($name);
+        Assert::notWhitespaceOnly($name);
 
         Assert::stringNotEmpty($className);
         Assert::notWhitespaceOnly($className);
@@ -45,14 +45,14 @@ final readonly class BlockDefinition
         Assert::string($values['className']);
         Assert::classExists($values['className']);
 
-        Assert::keyExists($values, 'technicalName');
-        Assert::string($values['technicalName']);
+        Assert::keyExists($values, 'name');
+        Assert::string($values['name']);
 
         Assert::keyExists($values, 'template');
         Assert::string($values['template']);
 
         return new self(
-            technicalName: $values['technicalName'],
+            name: $values['name'],
             className: $values['className'],
             template: $values['template'],
         );

--- a/src/Block/Exception/BlockNotFoundException.php
+++ b/src/Block/Exception/BlockNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Block\Exception;
+
+final class BlockNotFoundException extends \RuntimeException
+{
+}

--- a/src/Block/Renderer/BlockRenderer.php
+++ b/src/Block/Renderer/BlockRenderer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Block\Renderer;
+
+use Storyblok\Bundle\Block\BlockCollection;
+use Storyblok\Bundle\Block\Exception\BlockNotFoundException;
+use Twig\Environment;
+use Webmozart\Assert\Assert;
+
+final readonly class BlockRenderer implements RendererInterface
+{
+    public function __construct(
+        private Environment $twig,
+        private BlockCollection $blocks,
+    ) {
+    }
+
+    public function render(array $values): string
+    {
+        try {
+            Assert::keyExists($values, 'component');
+            $name = $values['component'];
+
+            $definition = $this->blocks->byTechnicalName($name);
+
+            return $this->twig->render($definition->template, ['block' => new ($definition->className)($values)]);
+        } catch (BlockNotFoundException) {
+            return '';
+        }
+    }
+}

--- a/src/Block/Renderer/BlockRenderer.php
+++ b/src/Block/Renderer/BlockRenderer.php
@@ -26,15 +26,22 @@ final readonly class BlockRenderer implements RendererInterface
     ) {
     }
 
-    public function render(array $values): string
+    public function render(array|object $values): string
     {
         try {
-            Assert::keyExists($values, 'component');
-            $name = $values['component'];
+            if (\is_object($values)) {
+                $definition = $this->blocks->get($values::class);
 
-            $definition = $this->blocks->byTechnicalName($name);
+                $block = $values;
+            } else {
+                Assert::keyExists($values, 'component');
+                $name = $values['component'];
+                $definition = $this->blocks->byTechnicalName($name);
 
-            return $this->twig->render($definition->template, ['block' => new ($definition->className)($values)]);
+                $block = new ($definition->className)($values);
+            }
+
+            return $this->twig->render($definition->template, ['block' => $block]);
         } catch (BlockNotFoundException) {
             return '';
         }

--- a/src/Block/Renderer/BlockRenderer.php
+++ b/src/Block/Renderer/BlockRenderer.php
@@ -36,7 +36,7 @@ final readonly class BlockRenderer implements RendererInterface
             } else {
                 Assert::keyExists($values, 'component');
                 $name = $values['component'];
-                $definition = $this->blocks->byTechnicalName($name);
+                $definition = $this->blocks->byName($name);
 
                 $block = new ($definition->className)($values);
             }

--- a/src/Block/Renderer/BlockRenderer.php
+++ b/src/Block/Renderer/BlockRenderer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Storyblok\Bundle\Block\Renderer;
 
-use Storyblok\Bundle\Block\BlockCollection;
+use Storyblok\Bundle\Block\BlockRegistry;
 use Storyblok\Bundle\Block\Exception\BlockNotFoundException;
 use Twig\Environment;
 use Webmozart\Assert\Assert;
@@ -22,7 +22,7 @@ final readonly class BlockRenderer implements RendererInterface
 {
     public function __construct(
         private Environment $twig,
-        private BlockCollection $blocks,
+        private BlockRegistry $blocks,
     ) {
     }
 
@@ -30,13 +30,13 @@ final readonly class BlockRenderer implements RendererInterface
     {
         try {
             if (\is_object($values)) {
-                $definition = $this->blocks->get($values::class);
+                $definition = $this->blocks::get($values::class);
 
                 $block = $values;
             } else {
                 Assert::keyExists($values, 'component');
                 $name = $values['component'];
-                $definition = $this->blocks->byName($name);
+                $definition = $this->blocks::byName($name);
 
                 $block = new ($definition->className)($values);
             }

--- a/src/Block/Renderer/RendererInterface.php
+++ b/src/Block/Renderer/RendererInterface.php
@@ -16,9 +16,9 @@ namespace Storyblok\Bundle\Block\Renderer;
 interface RendererInterface
 {
     /**
-     * @param array<string, mixed> $values The values of the block coming from Storyblok
+     * @param array<string, mixed>|object $values The values of the block coming from Storyblok
      *
      * @return string Returns HTML
      */
-    public function render(array $values): string;
+    public function render(array|object $values): string;
 }

--- a/src/Block/Renderer/RendererInterface.php
+++ b/src/Block/Renderer/RendererInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Block\Renderer;
+
+interface RendererInterface
+{
+    /**
+     * @param array<string, mixed> $values The values of the block coming from Storyblok
+     *
+     * @return string Returns HTML
+     */
+    public function render(array $values): string;
+}

--- a/src/DataCollector/StoryblokCollector.php
+++ b/src/DataCollector/StoryblokCollector.php
@@ -132,7 +132,7 @@ final class StoryblokCollector extends AbstractDataCollector implements LateData
                 $contentType = 'application/octet-stream';
 
                 foreach ($info['response_headers'] ?? [] as $h) {
-                    if (0 === stripos($h, 'content-type: ')) {
+                    if (str_starts_with(strtolower($h), strtolower('content-type: '))) {
                         $contentType = substr($h, \strlen('content-type: '));
 
                         break;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -50,6 +50,10 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('auto_resolve_relations')
                     ->defaultValue(false)
                 ->end()
+                ->scalarNode('blocks_template_path')
+                    ->defaultValue('blocks')
+                    ->cannotBeEmpty()
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -150,7 +150,7 @@ final class StoryblokExtension extends Extension
             $collectionDefinition = $container->getDefinition(BlockCollection::class);
             $collectionDefinition->addMethodCall('add', [[
                 'className' => $reflector->getName(),
-                'technicalName' => $name,
+                'name' => $name,
                 'template' => $template,
             ]]);
         });

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -23,7 +23,7 @@ use Storyblok\Api\StoriesResolvedApi;
 use Storyblok\Api\StoryblokClient;
 use Storyblok\Api\StoryblokClientInterface;
 use Storyblok\Bundle\Block\Attribute\AsBlock;
-use Storyblok\Bundle\Block\BlockCollection;
+use Storyblok\Bundle\Block\BlockRegistry;
 use Storyblok\Bundle\DataCollector\StoryblokCollector;
 use Storyblok\Bundle\Listener\UpdateProfilerListener;
 use Storyblok\Bundle\Webhook\Handler\WebhookHandlerInterface;
@@ -147,7 +147,7 @@ final class StoryblokExtension extends Extension
             $name = $attribute->name ?? u($reflector->getShortName())->snake()->toString();
             $template = $attribute->template ?? \sprintf('%s/%s.html.twig', $config['blocks_template_path'], $name);
 
-            $collectionDefinition = $container->getDefinition(BlockCollection::class);
+            $collectionDefinition = $container->getDefinition(BlockRegistry::class);
             $collectionDefinition->addMethodCall('add', [[
                 'className' => $reflector->getName(),
                 'name' => $name,

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -143,10 +143,8 @@ final class StoryblokExtension extends Extension
         $container->registerAttributeForAutoconfiguration(AsBlock::class, static function (
             ChildDefinition $definition,
             AsBlock $attribute,
-            \ReflectionClass|\ReflectionMethod|\Reflector $reflector,
+            \ReflectionClass $reflector,
         ) use ($container, $config): void {
-            Assert::isInstanceOf($reflector, \ReflectionClass::class, 'Only classes can be tagged with #[AsBlock].');
-
             $name = $attribute->technicalName ?? u($reflector->getShortName())->snake()->toString();
             $template = $attribute->template ?? \sprintf('%s/%s.html.twig', $config['blocks_template_path'], $name);
 

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -35,7 +35,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpClient\TraceableHttpClient;
-use Webmozart\Assert\Assert;
 use function Symfony\Component\String\u;
 
 final class StoryblokExtension extends Extension

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -144,7 +144,7 @@ final class StoryblokExtension extends Extension
             AsBlock $attribute,
             \ReflectionClass $reflector,
         ) use ($container, $config): void {
-            $name = $attribute->technicalName ?? u($reflector->getShortName())->snake()->toString();
+            $name = $attribute->name ?? u($reflector->getShortName())->snake()->toString();
             $template = $attribute->template ?? \sprintf('%s/%s.html.twig', $config['blocks_template_path'], $name);
 
             $collectionDefinition = $container->getDefinition(BlockCollection::class);

--- a/src/DependencyInjection/StoryblokExtension.php
+++ b/src/DependencyInjection/StoryblokExtension.php
@@ -22,16 +22,21 @@ use Storyblok\Api\StoriesApiInterface;
 use Storyblok\Api\StoriesResolvedApi;
 use Storyblok\Api\StoryblokClient;
 use Storyblok\Api\StoryblokClientInterface;
+use Storyblok\Bundle\Block\Attribute\AsBlock;
+use Storyblok\Bundle\Block\BlockCollection;
 use Storyblok\Bundle\DataCollector\StoryblokCollector;
 use Storyblok\Bundle\Listener\UpdateProfilerListener;
 use Storyblok\Bundle\Webhook\Handler\WebhookHandlerInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpClient\TraceableHttpClient;
+use Webmozart\Assert\Assert;
+use function Symfony\Component\String\u;
 
 final class StoryblokExtension extends Extension
 {
@@ -88,6 +93,8 @@ final class StoryblokExtension extends Extension
             $container->setDefinition(StoriesResolvedApi::class, $resolvedStoriesApi);
             $container->setAlias(StoriesApiInterface::class, StoriesResolvedApi::class);
         }
+
+        $this->registerAttributes($container, $config);
     }
 
     private function configureAssetsApi(ContainerBuilder $container): void
@@ -126,5 +133,29 @@ final class StoryblokExtension extends Extension
         );
 
         $container->setAlias(AssetsApiInterface::class, AssetsApi::class);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function registerAttributes(ContainerBuilder $container, array $config): void
+    {
+        $container->registerAttributeForAutoconfiguration(AsBlock::class, static function (
+            ChildDefinition $definition,
+            AsBlock $attribute,
+            \ReflectionClass|\ReflectionMethod|\Reflector $reflector,
+        ) use ($container, $config): void {
+            Assert::isInstanceOf($reflector, \ReflectionClass::class, 'Only classes can be tagged with #[AsBlock].');
+
+            $name = $attribute->technicalName ?? u($reflector->getShortName())->snake()->toString();
+            $template = $attribute->template ?? \sprintf('%s/%s.html.twig', $config['blocks_template_path'], $name);
+
+            $collectionDefinition = $container->getDefinition(BlockCollection::class);
+            $collectionDefinition->addMethodCall('add', [[
+                'className' => $reflector->getName(),
+                'technicalName' => $name,
+                'template' => $template,
+            ]]);
+        });
     }
 }

--- a/src/Twig/BlockExtension.php
+++ b/src/Twig/BlockExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Twig;
+
+use Storyblok\Bundle\Block\Renderer\RendererInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class BlockExtension extends AbstractExtension
+{
+    public function __construct(
+        private RendererInterface $renderer,
+    ) {
+    }
+
+    /**
+     * @return TwigFilter[]
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('render_block', $this->renderBlock(...), ['is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public function renderBlock(array $values): string
+    {
+        return $this->renderer->render($values);
+    }
+}

--- a/src/Twig/BlockExtension.php
+++ b/src/Twig/BlockExtension.php
@@ -30,15 +30,7 @@ final class BlockExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('render_block', $this->renderBlock(...), ['is_safe' => ['html']]),
+            new TwigFilter('render_block', $this->renderer->render(...), ['is_safe' => ['html']]),
         ];
-    }
-
-    /**
-     * @param array<string, mixed> $values
-     */
-    public function renderBlock(array $values): string
-    {
-        return $this->renderer->render($values);
     }
 }

--- a/tests/Double/Block/SampleBlock.php
+++ b/tests/Double/Block/SampleBlock.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Double\Block;
+
+use Storyblok\Bundle\Block\Attribute\AsBlock;
+use Webmozart\Assert\Assert;
+
+#[AsBlock]
+final readonly class SampleBlock
+{
+    public string $title;
+    public string $description;
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public function __construct(array $values)
+    {
+        Assert::keyExists($values, 'title');
+        $this->title = $values['title'];
+
+        Assert::keyExists($values, 'description');
+        $this->description = $values['description'];
+    }
+}

--- a/tests/Unit/Block/Attribute/AsBlockTest.php
+++ b/tests/Unit/Block/Attribute/AsBlockTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Unit\Block\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Bundle\Block\Attribute\AsBlock;
+use Storyblok\Bundle\Tests\Util\FakerTrait;
+
+final class AsBlockTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function defaults(): void
+    {
+        $block = new AsBlock();
+
+        self::assertNull($block->technicalName);
+        self::assertNull($block->template);
+    }
+
+    /**
+     * @test
+     */
+    public function technicalName(): void
+    {
+        $block = new AsBlock(
+            technicalName: $expected = self::faker()->word(),
+        );
+
+        self::assertSame($expected, $block->technicalName);
+    }
+
+    /**
+     * @test
+     */
+    public function template(): void
+    {
+        $block = new AsBlock(
+            template: $expected = self::faker()->word(),
+        );
+
+        self::assertSame($expected, $block->template);
+    }
+}

--- a/tests/Unit/Block/Attribute/AsBlockTest.php
+++ b/tests/Unit/Block/Attribute/AsBlockTest.php
@@ -28,20 +28,20 @@ final class AsBlockTest extends TestCase
     {
         $block = new AsBlock();
 
-        self::assertNull($block->technicalName);
+        self::assertNull($block->name);
         self::assertNull($block->template);
     }
 
     /**
      * @test
      */
-    public function technicalName(): void
+    public function name(): void
     {
         $block = new AsBlock(
-            technicalName: $expected = self::faker()->word(),
+            name: $expected = self::faker()->word(),
         );
 
-        self::assertSame($expected, $block->technicalName);
+        self::assertSame($expected, $block->name);
     }
 
     /**

--- a/tests/Unit/Block/BlockCollectionTest.php
+++ b/tests/Unit/Block/BlockCollectionTest.php
@@ -108,4 +108,16 @@ final class BlockCollectionTest extends TestCase
 
         $collection->byTechnicalName($faker->domainName());
     }
+
+    /**
+     * @test
+     */
+    public function getIterator(): void
+    {
+        $faker = self::faker();
+
+        $collection = new BlockCollection();
+
+        self::assertInstanceOf(\ArrayIterator::class, $collection->getIterator());
+    }
 }

--- a/tests/Unit/Block/BlockCollectionTest.php
+++ b/tests/Unit/Block/BlockCollectionTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Storyblok\Bundle\Tests\Unit\Block;
 
 use PHPUnit\Framework\TestCase;
-use Storyblok\Bundle\Block\BlockCollection;
 use Storyblok\Bundle\Block\BlockDefinition;
+use Storyblok\Bundle\Block\BlockRegistry;
 use Storyblok\Bundle\Block\Exception\BlockNotFoundException;
 use Storyblok\Bundle\Tests\Double\Block\SampleBlock;
 use Storyblok\Bundle\Tests\Util\FakerTrait;
@@ -31,8 +31,8 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockCollection();
-        $collection->add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $collection = new BlockRegistry();
+        $collection::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
         self::assertCount(1, $collection);
     }
@@ -46,8 +46,8 @@ final class BlockCollectionTest extends TestCase
 
         $values = ['name' => $faker->word(), 'className' => SampleBlock::class, 'template' => $faker->word()];
 
-        $collection = new BlockCollection();
-        $collection->add($values);
+        $collection = new BlockRegistry();
+        $collection::add($values);
 
         self::assertCount(1, $collection);
     }
@@ -59,10 +59,10 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockCollection();
-        $collection->add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $collection = new BlockRegistry();
+        $collection::add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
-        self::assertSame($block, $collection->get($block->className));
+        self::assertSame($block, $collection::get($block->className));
     }
 
     /**
@@ -72,13 +72,13 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockCollection();
-        $collection->add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $collection = new BlockRegistry();
+        $collection::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
         self::expectException(BlockNotFoundException::class);
         self::expectExceptionMessage(\sprintf('Block "%s" not found.', \stdClass::class));
 
-        $collection->get(\stdClass::class);
+        $collection::get(\stdClass::class);
     }
 
     /**
@@ -88,10 +88,10 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockCollection();
-        $collection->add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $collection = new BlockRegistry();
+        $collection::add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
-        self::assertSame($block, $collection->byName($block->name));
+        self::assertSame($block, $collection::byName($block->name));
     }
 
     /**
@@ -101,21 +101,11 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockCollection();
-        $collection->add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $collection = new BlockRegistry();
+        $collection::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
         self::expectException(BlockNotFoundException::class);
 
-        $collection->byName($faker->domainName());
-    }
-
-    /**
-     * @test
-     */
-    public function getIterator(): void
-    {
-        $collection = new BlockCollection();
-
-        self::assertInstanceOf(\ArrayIterator::class, $collection->getIterator());
+        $collection::byName($faker->domainName());
     }
 }

--- a/tests/Unit/Block/BlockCollectionTest.php
+++ b/tests/Unit/Block/BlockCollectionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Unit\Block;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Bundle\Block\BlockCollection;
+use Storyblok\Bundle\Block\BlockDefinition;
+use Storyblok\Bundle\Block\Exception\BlockNotFoundException;
+use Storyblok\Bundle\Tests\Double\Block\SampleBlock;
+use Storyblok\Bundle\Tests\Util\FakerTrait;
+
+final class BlockCollectionTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function add(): void
+    {
+        $faker = self::faker();
+
+        $collection = new BlockCollection();
+        $collection->add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+
+        self::assertCount(1, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function addWithArray(): void
+    {
+        $faker = self::faker();
+
+        $values = ['technicalName' => $faker->word(), 'className' => SampleBlock::class, 'template' => $faker->word()];
+
+        $collection = new BlockCollection();
+        $collection->add($values);
+
+        self::assertCount(1, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function get(): void
+    {
+        $faker = self::faker();
+
+        $collection = new BlockCollection();
+        $collection->add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+
+        self::assertSame($block, $collection->get($block->className));
+    }
+
+    /**
+     * @test
+     */
+    public function getThrowsExceptionWhenBlockDefinitionWasNotFound(): void
+    {
+        $faker = self::faker();
+
+        $collection = new BlockCollection();
+        $collection->add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+
+        self::expectException(BlockNotFoundException::class);
+        self::expectExceptionMessage(\sprintf('Block "%s" not found.', \stdClass::class));
+
+        $collection->get(\stdClass::class);
+    }
+
+    /**
+     * @test
+     */
+    public function byTechnicalName(): void
+    {
+        $faker = self::faker();
+
+        $collection = new BlockCollection();
+        $collection->add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+
+        self::assertSame($block, $collection->byTechnicalName($block->technicalName));
+    }
+
+    /**
+     * @test
+     */
+    public function byTechnicalNameThrowsExceptionWhenBlockDefinitionWasNotFound(): void
+    {
+        $faker = self::faker();
+
+        $collection = new BlockCollection();
+        $collection->add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+
+        self::expectException(BlockNotFoundException::class);
+
+        $collection->byTechnicalName($faker->domainName());
+    }
+}

--- a/tests/Unit/Block/BlockCollectionTest.php
+++ b/tests/Unit/Block/BlockCollectionTest.php
@@ -44,7 +44,7 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $values = ['technicalName' => $faker->word(), 'className' => SampleBlock::class, 'template' => $faker->word()];
+        $values = ['name' => $faker->word(), 'className' => SampleBlock::class, 'template' => $faker->word()];
 
         $collection = new BlockCollection();
         $collection->add($values);
@@ -84,20 +84,20 @@ final class BlockCollectionTest extends TestCase
     /**
      * @test
      */
-    public function byTechnicalName(): void
+    public function byName(): void
     {
         $faker = self::faker();
 
         $collection = new BlockCollection();
         $collection->add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
-        self::assertSame($block, $collection->byTechnicalName($block->technicalName));
+        self::assertSame($block, $collection->byName($block->name));
     }
 
     /**
      * @test
      */
-    public function byTechnicalNameThrowsExceptionWhenBlockDefinitionWasNotFound(): void
+    public function byNameThrowsExceptionWhenBlockDefinitionWasNotFound(): void
     {
         $faker = self::faker();
 
@@ -106,7 +106,7 @@ final class BlockCollectionTest extends TestCase
 
         self::expectException(BlockNotFoundException::class);
 
-        $collection->byTechnicalName($faker->domainName());
+        $collection->byName($faker->domainName());
     }
 
     /**
@@ -114,8 +114,6 @@ final class BlockCollectionTest extends TestCase
      */
     public function getIterator(): void
     {
-        $faker = self::faker();
-
         $collection = new BlockCollection();
 
         self::assertInstanceOf(\ArrayIterator::class, $collection->getIterator());

--- a/tests/Unit/Block/BlockDefinitionTest.php
+++ b/tests/Unit/Block/BlockDefinitionTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Unit\Block;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Bundle\Block\BlockDefinition;
+use Storyblok\Bundle\Tests\Double\Block\SampleBlock;
+use Storyblok\Bundle\Tests\Util\FakerTrait;
+
+final class BlockDefinitionTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function technicalName(): void
+    {
+        $faker = self::faker();
+        $expected = $faker->word();
+
+        self::assertSame($expected, (new BlockDefinition($expected, SampleBlock::class, 'sample/block.html.twig'))->technicalName);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
+     */
+    public function technicalNameInvalid(string $value): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new BlockDefinition($value, SampleBlock::class, 'sample/block.html.twig');
+    }
+
+    /**
+     * @test
+     */
+    public function className(): void
+    {
+        $faker = self::faker();
+        $expected = SampleBlock::class;
+
+        self::assertSame($expected, (new BlockDefinition($faker->word(), $expected, 'sample/block.html.twig'))->className);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
+     */
+    public function classNameInvalid(string $value): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new BlockDefinition(self::faker()->word(), $value, 'sample/block.html.twig');
+    }
+
+    /**
+     * @test
+     */
+    public function classNameClassMustExist(): void
+    {
+        $faker = self::faker();
+        self::expectException(\InvalidArgumentException::class);
+
+        new BlockDefinition($faker->word(), $faker->word(), 'sample/block.html.twig');
+    }
+
+    /**
+     * @test
+     */
+    public function template(): void
+    {
+        $faker = self::faker();
+        $expected = $faker->word();
+
+        self::assertSame($expected, (new BlockDefinition($faker->word(), SampleBlock::class, $expected))->template);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
+     */
+    public function templateInvalid(string $value): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new BlockDefinition(self::faker()->word(), SampleBlock::class, $value);
+    }
+
+    /**
+     * @test
+     */
+    public function fromArray(): void
+    {
+        $expected = new BlockDefinition(
+            'sample_block',
+            SampleBlock::class,
+            'sample/block.html.twig',
+        );
+
+        self::assertEquals($expected, BlockDefinition::fromArray([
+            'technicalName' => $expected->technicalName,
+            'className' => $expected->className,
+            'template' => $expected->template,
+        ]));
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayTechnicalNameKeyMustExist(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        BlockDefinition::fromArray([
+            'className' => SampleBlock::class,
+            'template' => self::faker()->word(),
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayTechnicalNameInvalid(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        BlockDefinition::fromArray([
+            'technicalName' => self::faker()->randomNumber(),
+            'className' => SampleBlock::class,
+            'template' => self::faker()->word(),
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayClassNameKeyMustExist(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        BlockDefinition::fromArray([
+            'technicalName' => SampleBlock::class,
+            'template' => self::faker()->word(),
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayClassNameInvalid(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        BlockDefinition::fromArray([
+            'technicalName' => self::faker()->randomNumber(),
+            'className' => self::faker()->randomNumber(),
+            'template' => self::faker()->word(),
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayTemplateKeyMustExist(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        BlockDefinition::fromArray([
+            'technicalName' => self::faker()->word(),
+            'className' => SampleBlock::class,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayTemplateInvalid(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        BlockDefinition::fromArray([
+            'technicalName' => self::faker()->randomNumber(),
+            'className' => self::faker()->randomNumber(),
+            'template' => self::faker()->randomNumber(),
+        ]);
+    }
+}

--- a/tests/Unit/Block/BlockDefinitionTest.php
+++ b/tests/Unit/Block/BlockDefinitionTest.php
@@ -25,12 +25,12 @@ final class BlockDefinitionTest extends TestCase
     /**
      * @test
      */
-    public function technicalName(): void
+    public function name(): void
     {
         $faker = self::faker();
         $expected = $faker->word();
 
-        self::assertSame($expected, (new BlockDefinition($expected, SampleBlock::class, 'sample/block.html.twig'))->technicalName);
+        self::assertSame($expected, (new BlockDefinition($expected, SampleBlock::class, 'sample/block.html.twig'))->name);
     }
 
     /**
@@ -39,7 +39,7 @@ final class BlockDefinitionTest extends TestCase
      * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
      * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
      */
-    public function technicalNameInvalid(string $value): void
+    public function nameInvalid(string $value): void
     {
         self::expectException(\InvalidArgumentException::class);
 
@@ -117,7 +117,7 @@ final class BlockDefinitionTest extends TestCase
         );
 
         self::assertEquals($expected, BlockDefinition::fromArray([
-            'technicalName' => $expected->technicalName,
+            'name' => $expected->name,
             'className' => $expected->className,
             'template' => $expected->template,
         ]));
@@ -126,7 +126,7 @@ final class BlockDefinitionTest extends TestCase
     /**
      * @test
      */
-    public function fromArrayTechnicalNameKeyMustExist(): void
+    public function fromArraynameKeyMustExist(): void
     {
         self::expectException(\InvalidArgumentException::class);
 
@@ -139,12 +139,12 @@ final class BlockDefinitionTest extends TestCase
     /**
      * @test
      */
-    public function fromArrayTechnicalNameInvalid(): void
+    public function fromArraynameInvalid(): void
     {
         self::expectException(\InvalidArgumentException::class);
 
         BlockDefinition::fromArray([
-            'technicalName' => self::faker()->randomNumber(),
+            'name' => self::faker()->randomNumber(),
             'className' => SampleBlock::class,
             'template' => self::faker()->word(),
         ]);
@@ -158,7 +158,7 @@ final class BlockDefinitionTest extends TestCase
         self::expectException(\InvalidArgumentException::class);
 
         BlockDefinition::fromArray([
-            'technicalName' => SampleBlock::class,
+            'name' => SampleBlock::class,
             'template' => self::faker()->word(),
         ]);
     }
@@ -171,7 +171,7 @@ final class BlockDefinitionTest extends TestCase
         self::expectException(\InvalidArgumentException::class);
 
         BlockDefinition::fromArray([
-            'technicalName' => self::faker()->randomNumber(),
+            'name' => self::faker()->randomNumber(),
             'className' => self::faker()->randomNumber(),
             'template' => self::faker()->word(),
         ]);
@@ -185,7 +185,7 @@ final class BlockDefinitionTest extends TestCase
         self::expectException(\InvalidArgumentException::class);
 
         BlockDefinition::fromArray([
-            'technicalName' => self::faker()->word(),
+            'name' => self::faker()->word(),
             'className' => SampleBlock::class,
         ]);
     }
@@ -198,7 +198,7 @@ final class BlockDefinitionTest extends TestCase
         self::expectException(\InvalidArgumentException::class);
 
         BlockDefinition::fromArray([
-            'technicalName' => self::faker()->randomNumber(),
+            'name' => self::faker()->randomNumber(),
             'className' => self::faker()->randomNumber(),
             'template' => self::faker()->randomNumber(),
         ]);

--- a/tests/Unit/Block/Renderer/BlockRendererTest.php
+++ b/tests/Unit/Block/Renderer/BlockRendererTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Unit\Block\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Bundle\Block\BlockCollection;
+use Storyblok\Bundle\Block\BlockDefinition;
+use Storyblok\Bundle\Block\Renderer\BlockRenderer;
+use Storyblok\Bundle\Tests\Double\Block\SampleBlock;
+use Storyblok\Bundle\Tests\Util\FakerTrait;
+use Twig\Environment;
+
+final class BlockRendererTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function render(): void
+    {
+        $faker = self::faker();
+
+        $expected = $faker->realText();
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::once())
+            ->method('render')
+            ->willReturn($expected);
+
+        $collection = new BlockCollection([
+            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
+        ]);
+
+        $values = [
+            'component' => 'sample_block',
+            'title' => $faker->sentence(),
+            'description' => $faker->realText(),
+        ];
+
+        self::assertSame($expected, (new BlockRenderer($twig, $collection))->render($values));
+    }
+
+    /**
+     * @test
+     */
+    public function renderValuesComponentKeyMustExist(): void
+    {
+        $faker = self::faker();
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::never())
+            ->method('render');
+
+        $collection = new BlockCollection([
+            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
+        ]);
+
+        $values = [
+            'title' => $faker->sentence(),
+            'description' => $faker->realText(),
+        ];
+
+        self::expectException(\InvalidArgumentException::class);
+
+        (new BlockRenderer($twig, $collection))->render($values);
+    }
+
+    /**
+     * @test
+     */
+    public function renderCatchesBlockNotFoundExceptionAndReturnsEmptyString(): void
+    {
+        $faker = self::faker();
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::never())
+            ->method('render');
+
+        $collection = new BlockCollection([
+            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
+        ]);
+
+        $values = [
+            'component' => $faker->word(),
+            'title' => $faker->sentence(),
+            'description' => $faker->realText(),
+        ];
+
+        self::assertSame('', (new BlockRenderer($twig, $collection))->render($values));
+    }
+}

--- a/tests/Unit/Block/Renderer/BlockRendererTest.php
+++ b/tests/Unit/Block/Renderer/BlockRendererTest.php
@@ -55,6 +55,33 @@ final class BlockRendererTest extends TestCase
     /**
      * @test
      */
+    public function renderWithObject(): void
+    {
+        $faker = self::faker();
+
+        $expected = $faker->realText();
+
+        $twig = $this->createMock(Environment::class);
+        $twig->expects(self::once())
+            ->method('render')
+            ->willReturn($expected);
+
+        $collection = new BlockCollection([
+            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
+        ]);
+
+        $values = new SampleBlock([
+            'component' => 'sample_block',
+            'title' => $faker->sentence(),
+            'description' => $faker->realText(),
+        ]);
+
+        self::assertSame($expected, (new BlockRenderer($twig, $collection))->render($values));
+    }
+
+    /**
+     * @test
+     */
     public function renderValuesComponentKeyMustExist(): void
     {
         $faker = self::faker();

--- a/tests/Unit/Block/Renderer/BlockRendererTest.php
+++ b/tests/Unit/Block/Renderer/BlockRendererTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Storyblok\Bundle\Tests\Unit\Block\Renderer;
 
 use PHPUnit\Framework\TestCase;
-use Storyblok\Bundle\Block\BlockCollection;
 use Storyblok\Bundle\Block\BlockDefinition;
+use Storyblok\Bundle\Block\BlockRegistry;
 use Storyblok\Bundle\Block\Renderer\BlockRenderer;
 use Storyblok\Bundle\Tests\Double\Block\SampleBlock;
 use Storyblok\Bundle\Tests\Util\FakerTrait;
@@ -39,9 +39,8 @@ final class BlockRendererTest extends TestCase
             ->method('render')
             ->willReturn($expected);
 
-        $collection = new BlockCollection([
-            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
-        ]);
+        $collection = new BlockRegistry();
+        $collection::add(new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'));
 
         $values = [
             'component' => 'sample_block',
@@ -66,9 +65,8 @@ final class BlockRendererTest extends TestCase
             ->method('render')
             ->willReturn($expected);
 
-        $collection = new BlockCollection([
-            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
-        ]);
+        $collection = new BlockRegistry();
+        $collection::add(new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'));
 
         $values = new SampleBlock([
             'component' => 'sample_block',
@@ -90,9 +88,8 @@ final class BlockRendererTest extends TestCase
         $twig->expects(self::never())
             ->method('render');
 
-        $collection = new BlockCollection([
-            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
-        ]);
+        $collection = new BlockRegistry();
+        $collection::add(new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'));
 
         $values = [
             'title' => $faker->sentence(),
@@ -115,9 +112,8 @@ final class BlockRendererTest extends TestCase
         $twig->expects(self::never())
             ->method('render');
 
-        $collection = new BlockCollection([
-            new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'),
-        ]);
+        $collection = new BlockRegistry();
+        $collection::add(new BlockDefinition('sample_block', SampleBlock::class, 'sample/block.html.twig'));
 
         $values = [
             'component' => $faker->word(),

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -34,6 +34,7 @@ final class ConfigurationTest extends TestCase
         $secret = $faker->uuid();
         $version = $faker->randomElement(['draft', 'published']);
         $autoResolve = $faker->boolean();
+        $templatePath = $faker->word();
 
         self::assertProcessedConfigurationEquals([
             ['base_uri' => $url],
@@ -41,12 +42,14 @@ final class ConfigurationTest extends TestCase
             ['webhook_secret' => $secret],
             ['version' => $version],
             ['auto_resolve_relations' => $autoResolve],
+            ['blocks_template_path' => $templatePath],
         ], [
             'base_uri' => $url,
             'token' => $token,
             'webhook_secret' => $secret,
             'version' => $version,
             'auto_resolve_relations' => $autoResolve,
+            'blocks_template_path' => $templatePath,
         ]);
     }
 
@@ -68,6 +71,7 @@ final class ConfigurationTest extends TestCase
             'webhook_secret' => null,
             'version' => 'published',
             'auto_resolve_relations' => false,
+            'blocks_template_path' => 'blocks',
         ]);
     }
 

--- a/tests/Unit/Twig/BlockExtensionTest.php
+++ b/tests/Unit/Twig/BlockExtensionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Storyblok\Bundle\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Bundle\Block\Renderer\RendererInterface;
+use Storyblok\Bundle\Twig\BlockExtension;
+
+final class BlockExtensionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getFilters(): void
+    {
+        $renderer = $this->createMock(RendererInterface::class);
+
+        $filters = (new BlockExtension($renderer))->getFilters();
+
+        self::assertCount(1, $filters);
+        self::assertSame('render_block', $filters[0]->getName());
+    }
+}

--- a/tests/Unit/Twig/BlockExtensionTest.php
+++ b/tests/Unit/Twig/BlockExtensionTest.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of sensiolabs-de/storyblok-bundle.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Storyblok\Bundle\Tests\Unit\Twig;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This PR introduces a powerful new way to define Storyblok blocks in Symfony applications using the `#[AsBlock]` attribute. This feature enables developers to register blocks generically, ensuring consistency and simplifying block management.

### **Key Features**

#### 1. **`#[AsBlock]` Attribute**
- Allows defining a block with an optional `name` and `template`.
- If `name` is omitted, the system will automatically convert the class name to camelCase (e.g., `SampleBlock` → `sample_block`).
- The `template` parameter specifies the Twig template used for rendering. If omitted, a default template path is derived.

#### 2. **Default Template Path Configuration**
- Blocks are rendered using a default path:  
  ```
  blocks/{name}.html.twig
  ```
- This can be customized via configuration:
  ```yaml
  # config/packages/storyblok.yaml
  storyblok:
      blocks_template_path: 'my/custom/path'
  ```

#### 3. **New Twig Extension: `BlockExtension`**
- Provides the `render_block` filter for rendering Storyblok blocks effortlessly.
- Example usage:
  ```twig
  {% for block in page.body %}
      {% if block is not null %}
          {{ block|render_block }}
      {% endif %}
  {% endfor %}
  ```

### **Example: Defining a Block with `#[AsBlock]`**
```php
namespace Storyblok\Bundle\Tests\Double\Block;

use Storyblok\Bundle\Block\Attribute\AsBlock;
use Webmozart\Assert\Assert;

#[AsBlock(technicalName: 'sample', template: 'custom_blocks/sample.html.twig')]
final readonly class SampleBlock
{
    public string $title;
    public string $description;

    public function __construct(array $values)
    {
        Assert::keyExists($values, 'title');
        $this->title = $values['title'];

        Assert::keyExists($values, 'description');
        $this->description = $values['description'];
    }
}
```

This class:
- Registers a Storyblok block named `sample_block`.
- Uses a custom template at `custom_blocks/sample.html.twig`.
- Ensures proper structure via assertions.

This PR brings significant flexibility and ease to managing Storyblok blocks within Symfony, making integration more intuitive and robust.
