### PR TITLE
Supports array in `AsBlock->name` argument

### DIFF
--- a/src/Block/BlockRegistry.php
+++ b/src/Block/BlockRegistry.php
@@ -18,7 +18,7 @@ use Storyblok\Bundle\Block\Exception\BlockNotFoundException;
 final class BlockRegistry implements \Countable
 {
     /**
-     * @var array<class-string, BlockDefinition>
+     * @var array<string, BlockDefinition>
      */
     public static array $blocks = [];
 
@@ -36,33 +36,33 @@ final class BlockRegistry implements \Countable
             $definition = BlockDefinition::fromArray($definition);
         }
 
-        self::$blocks[$definition->className] = $definition;
+        self::$blocks[$definition->name] = $definition;
     }
 
     /**
      * @param class-string $fqcn
      */
-    public static function get(string $fqcn): BlockDefinition
+    public static function byClass(string $fqcn): BlockDefinition
     {
-        if (!\array_key_exists($fqcn, self::$blocks)) {
+        $definitions = \array_values(\array_filter(
+            self::$blocks,
+            static fn (BlockDefinition $definition) => $definition->className === $fqcn,
+        ));
+
+        if (0 === \count($definitions)) {
             throw new BlockNotFoundException(\sprintf('Block "%s" not found.', $fqcn));
         }
 
-        return self::$blocks[$fqcn];
+        return $definitions[0];
     }
 
     public static function byName(string $name): BlockDefinition
     {
-        $definitions = \array_values(\array_filter(
-            self::$blocks,
-            static fn (BlockDefinition $definition) => $definition->name === $name,
-        ));
-
-        if (0 === \count($definitions)) {
+        if (!\array_key_exists($name, self::$blocks)) {
             throw new BlockNotFoundException(\sprintf('Block "%s" not found.', $name));
         }
 
-        return $definitions[0];
+        return self::$blocks[$name];
     }
 
     public function count(): int

--- a/src/Block/BlockRegistry.php
+++ b/src/Block/BlockRegistry.php
@@ -20,7 +20,7 @@ final class BlockRegistry implements \Countable
     /**
      * @var array<string, BlockDefinition>
      */
-    public static array $blocks = [];
+    private static array $blocks = [];
 
     public function __construct()
     {

--- a/src/Block/Renderer/BlockRenderer.php
+++ b/src/Block/Renderer/BlockRenderer.php
@@ -30,7 +30,7 @@ final readonly class BlockRenderer implements RendererInterface
     {
         try {
             if (\is_object($values)) {
-                $definition = $this->blocks::get($values::class);
+                $definition = $this->blocks::byClass($values::class);
 
                 $block = $values;
             } else {

--- a/tests/Unit/Block/BlockCollectionTest.php
+++ b/tests/Unit/Block/BlockCollectionTest.php
@@ -23,6 +23,16 @@ use Storyblok\Bundle\Tests\Util\FakerTrait;
 final class BlockCollectionTest extends TestCase
 {
     use FakerTrait;
+    private BlockRegistry $registry;
+
+    protected function setUp(): void
+    {
+        $this->registry = new BlockRegistry();
+
+        $reflection = new \ReflectionClass($this->registry);
+        $property = $reflection->getProperty('blocks');
+        $property->setValue($this->registry, []);
+    }
 
     /**
      * @test
@@ -31,10 +41,9 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockRegistry();
-        $collection::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $this->registry::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
-        self::assertCount(1, $collection);
+        self::assertCount(1, $this->registry);
     }
 
     /**
@@ -46,39 +55,36 @@ final class BlockCollectionTest extends TestCase
 
         $values = ['name' => $faker->word(), 'className' => SampleBlock::class, 'template' => $faker->word()];
 
-        $collection = new BlockRegistry();
-        $collection::add($values);
+        $this->registry::add($values);
 
-        self::assertCount(1, $collection);
+        self::assertCount(1, $this->registry);
     }
 
     /**
      * @test
      */
-    public function get(): void
+    public function byClass(): void
     {
         $faker = self::faker();
 
-        $collection = new BlockRegistry();
-        $collection::add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $this->registry::add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
-        self::assertSame($block, $collection::get($block->className));
+        self::assertSame($block, $this->registry::byClass($block->className));
     }
 
     /**
      * @test
      */
-    public function getThrowsExceptionWhenBlockDefinitionWasNotFound(): void
+    public function byClassThrowsExceptionWhenBlockDefinitionWasNotFound(): void
     {
         $faker = self::faker();
 
-        $collection = new BlockRegistry();
-        $collection::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $this->registry::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
         self::expectException(BlockNotFoundException::class);
         self::expectExceptionMessage(\sprintf('Block "%s" not found.', \stdClass::class));
 
-        $collection::get(\stdClass::class);
+        $this->registry::byClass(\stdClass::class);
     }
 
     /**
@@ -88,10 +94,9 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockRegistry();
-        $collection::add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $this->registry::add($block = new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
-        self::assertSame($block, $collection::byName($block->name));
+        self::assertSame($block, $this->registry::byName($block->name));
     }
 
     /**
@@ -101,11 +106,10 @@ final class BlockCollectionTest extends TestCase
     {
         $faker = self::faker();
 
-        $collection = new BlockRegistry();
-        $collection::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
+        $this->registry::add(new BlockDefinition($faker->word(), SampleBlock::class, $faker->word()));
 
         self::expectException(BlockNotFoundException::class);
 
-        $collection::byName($faker->domainName());
+        $this->registry::byName($faker->domainName());
     }
 }


### PR DESCRIPTION
This pullrequest should allow multiple attributes on one class for example:

```php
use Storyblok\Bundle\Block\Attribute\AsBlock;

#[AsBlock(name: 'youtube_video')]
#[AsBlock(name: 'spotify_embed')]
#[AsBlock(name: 'instagram_embed')]
#[AsBlock(name: 'linkedin_embed')]
final readonly class Embed
{
    public string $url;

    /**
     * @param array<string, mixed> $values
     */
    public function __construct(array $values)
    {
        $this->url = $values['url'];
    }
}

```