### PR TITLE
feat(rich_text): Deprecate `array` argument `richt_text` twig filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=8.3",
     "oskarstark/enum-helper": "^1.6",
     "psr/log": "^3.0",
-    "storyblok/php-content-api-client": ">=1.5.0",
+    "storyblok/php-content-api-client": ">=1.5.2",
     "storyblok/php-tiptap-extension": "^1.0",
     "symfony/config": "^6.0 || ^7.0",
     "symfony/dependency-injection": "^6.0 || ^7.0",

--- a/src/Tiptap/EditorBuilderInterface.php
+++ b/src/Tiptap/EditorBuilderInterface.php
@@ -21,7 +21,7 @@ interface EditorBuilderInterface
     /**
      * @param array{
      *     type: 'doc',
-     *     content: list<array<string, mixed>>
+     *     content: list<mixed[]>
      * } $values
      */
     public function getEditor(array $values): Editor;

--- a/src/Twig/RichTextExtension.php
+++ b/src/Twig/RichTextExtension.php
@@ -37,7 +37,7 @@ final class RichTextExtension extends AbstractExtension
     }
 
     /**
-     * @param RichText|array{type: 'doc', content: list<array<string, mixed>>} $richText
+     * @param RichText|array{type: 'doc', content: list<mixed[]>} $richText
      */
     public function richText(RichText|array $richText): string
     {

--- a/src/Twig/RichTextExtension.php
+++ b/src/Twig/RichTextExtension.php
@@ -42,6 +42,7 @@ final class RichTextExtension extends AbstractExtension
     public function richText(RichText|array $richText): string
     {
         if (\is_array($richText)) {
+            @trigger_deprecation('storyblok/symfony-bundle', '1.4', 'Passing an array to "%s" is deprecated, use "%s" instead.', __METHOD__, RichText::class);
             $richText = new RichText($richText);
         }
 

--- a/src/Twig/RichTextExtension.php
+++ b/src/Twig/RichTextExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Storyblok\Bundle\Twig;
 
+use Storyblok\Api\Domain\Type\RichText;
 use Storyblok\Bundle\Tiptap\EditorBuilderInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -36,10 +37,14 @@ final class RichTextExtension extends AbstractExtension
     }
 
     /**
-     * @param array{type: 'doc', content: list<array<string, mixed>>} $richText
+     * @param RichText|array{type: 'doc', content: list<array<string, mixed>>} $richText
      */
-    public function richText(array $richText): string
+    public function richText(RichText|array $richText): string
     {
-        return $this->builder->getEditor($richText)->getHTML();
+        if (\is_array($richText)) {
+            $richText = new RichText($richText);
+        }
+
+        return $this->builder->getEditor($richText->toArray())->getHTML();
     }
 }

--- a/tests/Unit/Twig/RichTextExtensionTest.php
+++ b/tests/Unit/Twig/RichTextExtensionTest.php
@@ -16,6 +16,7 @@ namespace Storyblok\Bundle\Tests\Unit\Twig;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Storyblok\Api\Domain\Type\RichText;
 use Storyblok\Bundle\Tests\Util\FakerTrait;
 use Storyblok\Bundle\Tiptap\EditorBuilderInterface;
 use Storyblok\Bundle\Twig\RichTextExtension;
@@ -37,7 +38,7 @@ final class RichTextExtensionTest extends TestCase
     }
 
     #[Test]
-    public function richText(): void
+    public function richTextWithArray(): void
     {
         $expected = self::faker()->randomHtml();
 
@@ -55,5 +56,26 @@ final class RichTextExtensionTest extends TestCase
             ->willReturn($editor);
 
         self::assertSame($expected, (new RichTextExtension($builder))->richText($richText));
+    }
+
+    #[Test]
+    public function richText(): void
+    {
+        $expected = self::faker()->randomHtml();
+
+        $editor = self::createMock(Editor::class);
+        $editor->expects(self::once())
+            ->method('getHTML')
+            ->willReturn($expected);
+
+        $richText = ['type' => 'doc', 'content' => []];
+
+        $builder = self::createMock(EditorBuilderInterface::class);
+        $builder->expects(self::once())
+            ->method('getEditor')
+            ->with($richText)
+            ->willReturn($editor);
+
+        self::assertSame($expected, (new RichTextExtension($builder))->richText(new RichText($richText)));
     }
 }


### PR DESCRIPTION
Once this is merged i will deprecate array usage for this:

```php
@trigger_deprecation('storyblok/symfony-bundle', '1.4', 'Passing an array to "%s" is deprecated, use "%s" instead.', __METHOD__, RichText::class);

```