### PR TITLE
fix: slugs containing special chars

### DIFF
--- a/src/ContentType/Listener/ResolveControllerListener.php
+++ b/src/ContentType/Listener/ResolveControllerListener.php
@@ -26,6 +26,7 @@ use Storyblok\Bundle\ContentType\ContentTypeStorageInterface;
 use Storyblok\Bundle\ContentType\Exception\ContentTypeControllerNotFoundException;
 use Storyblok\Bundle\ContentType\Exception\InvalidStoryException;
 use Storyblok\Bundle\ContentType\Exception\StoryNotFoundException;
+use Storyblok\Bundle\ContentType\UnicodeSlug;
 use Storyblok\Bundle\Routing\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -63,10 +64,10 @@ final readonly class ResolveControllerListener
             return;
         }
 
-        $slug = $params['slug'];
+        $slug = new UnicodeSlug($params['slug']);
 
         try {
-            $response = $this->stories->bySlug($slug, new StoryRequest(
+            $response = $this->stories->bySlug($slug->toString(), new StoryRequest(
                 language: $request->getLocale(),
                 version: Version::from($this->version),
             ));

--- a/src/ContentType/UnicodeSlug.php
+++ b/src/ContentType/UnicodeSlug.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/symfony-bundle.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\ContentType;
+
+use OskarStark\Value\TrimmedNonEmptyString;
+use function Symfony\Component\String\u;
+
+/**
+ * @internal
+ *
+ * We must URL encode the slug value to ensure it is safe for use in URLs. Storyblok slugs can contain special
+ * characters, spaces, and other characters that may not be URL-safe.
+ */
+final readonly class UnicodeSlug implements \Stringable
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $value = TrimmedNonEmptyString::fromString($value)->toString();
+
+        $urlEncodedValue = '';
+
+        foreach (u($value)->split('/') as $key => $part) {
+            if (0 < $key) {
+                $urlEncodedValue .= '/';
+            }
+
+            $urlEncodedValue .= urlencode($part->toString());
+        }
+
+        $this->value = u($urlEncodedValue)
+            ->trimEnd('/')
+            ->trimStart('/')
+            ->toString();
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Unit/ContentType/UnicodeSlugTest.php
+++ b/tests/Unit/ContentType/UnicodeSlugTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/symfony-bundle.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Unit\ContentType;
+
+use Ergebnis\DataProvider\StringProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Storyblok\Bundle\ContentType\UnicodeSlug;
+use Storyblok\Bundle\Tests\Util\FakerTrait;
+
+final class UnicodeSlugTest extends TestCase
+{
+    use FakerTrait;
+
+    #[DataProvider('slugs')]
+    #[Test]
+    public function value(string $expected, string $value): void
+    {
+        self::assertSame($expected, (new UnicodeSlug($value))->toString());
+        self::assertSame($expected, (new UnicodeSlug($value))->__toString());
+        self::assertSame($expected, (string) new UnicodeSlug($value));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function slugs(): iterable
+    {
+        yield 'single word' => ['hello', 'hello'];
+        yield 'with slash prefix' => ['hello', '/hello'];
+        yield 'with trailing slash' => ['hello', 'hello/'];
+        yield 'with dash' => ['hello-world', 'hello-world'];
+        yield 'with underscore' => ['hello_world', 'hello_world'];
+        yield 'with cyrillic characters' => ['%D0%BF%D1%80%D0%B8%D0%B2%D1%96%D1%82-%D1%81%D0%B2%D1%96%D1%82', 'привіт-світ'];
+        yield 'with cyrillic nested path' => ['%D0%BC%D1%96%D0%B9-%D0%B1%D0%BB%D0%BE%D0%B3/%D0%BF%D1%80%D0%B8%D0%B2%D1%96%D1%82-%D1%81%D0%B2%D1%96%D1%82', 'мій-блог/привіт-світ'];
+        yield 'with mandarin characters' => ['%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C', '你好世界'];
+        yield 'with hindi characters' => ['%E0%A4%B9%E0%A5%88%E0%A4%B2%E0%A5%8B-%E0%A4%B5%E0%A4%B0%E0%A5%8D%E0%A4%B2%E0%A5%8D%E0%A4%A1', 'हैलो-वर्ल्ड'];
+    }
+
+    #[DataProviderExternal(StringProvider::class, 'blank')]
+    #[DataProviderExternal(StringProvider::class, 'empty')]
+    #[Test]
+    public function invalid(string $value): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new UnicodeSlug($value);
+    }
+}


### PR DESCRIPTION
Having japanese or cyrillic characters in the slugs results in a 404 Http not found error. so we must url encode  the slug parts.