### PR TITLE
feat(dx): Add `HelperTrait` for better validation of values

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,21 +204,33 @@ The bundle provides a convenient way to handle Storyblok content types and integ
 
 A content type object is a PHP class that represents a Storyblok content type. For example the following code
 
+> [!TIP]
+> Consider using the `HelperTrait` included in this bundle to streamline the handling of Storyblok API responses.
+> Real-world content data is often inconsistent — keys may be missing, values may have unexpected formats, or fields might be empty.
+> The helper methods in this trait handle these edge cases for you, allowing you to write clean, defensive, and readable code with minimal boilerplate.
+>
+> [Read more →](#helpers)
+
 ```php
 // ...
 use Storyblok\Bundle\ContentType\ContentType;
+use Storyblok\Bundle\Util\HelperTrait;
 
 final readonly class Page extends ContentType
 {
+    use HelperTrait;
+
     public string $uuid;
     public string $title;
     private \DateTimeImmutable $publishedAt;
 
     public function __construct(array $values)
     {
-        $this->uuid = $values['uuid'];
-        $this->title = $values['content']['title'];
-        $this->publishedAt = new \DateTimeImmutable($values['published_at']);
+        $this->uuid = self::string($values, 'uuid');
+        $this->publishedAt = self::DateTimeImmutable($values, 'published_at');
+
+        $content = $values['content']
+        $this->title = self::string($content, 'title');
     }
 
     public function publishedAt(): \DateTimeImmutable
@@ -379,6 +391,13 @@ The `name` and `template` parameters are optional, you will find their defaults 
 
 ### Usage
 
+> [!TIP]
+> Consider using the `HelperTrait` included in this bundle to streamline the handling of Storyblok API responses.
+> Real-world content data is often inconsistent — keys may be missing, values may have unexpected formats, or fields might be empty.
+> The helper methods in this trait handle these edge cases for you, allowing you to write clean, defensive, and readable code with minimal boilerplate.
+>
+> [Read more →](#helpers)
+
 To define a block, use the attribute on a class:
 
 ```php
@@ -511,6 +530,13 @@ allowing them to receive Storyblok’s `_editable` metadata:
 }
 ```
 
+> [!TIP]
+> Consider using the `HelperTrait` included in this bundle to streamline the handling of Storyblok API responses.
+> Real-world content data is often inconsistent — keys may be missing, values may have unexpected formats, or fields might be empty.
+> The helper methods in this trait handle these edge cases for you, allowing you to write clean, defensive, and readable code with minimal boilerplate.
+>
+> [Read more →](#helpers)
+
 This setup ensures Storyblok provides the necessary metadata to each block instance.
 
 3. **Render editable markers in your templates**
@@ -527,6 +553,37 @@ editable block is located:
 With this in place, components are “highlightable” in the Live Editor — clicking them opens the edit form seamlessly.
 
 ![Live Editor Example](docs/live-editor.webp)
+
+
+### Helpers
+
+The `Storyblok\Bundle\Util\HelperTrait` provides utility methods for mapping raw Storyblok data arrays into strong PHP value objects, enums, and domain models. These helpers reduce boilerplate code and improve readability in DTO constructors or factory methods.
+
+Use this trait in your value objects or models to simplify the parsing and validation of Storyblok field values.
+
+#### Available Methods
+
+| Method                | Description                                                                                                      |
+|-----------------------|------------------------------------------------------------------------------------------------------------------|
+| `one()`               | Expects exactly one item (e.g. from a `blocks` field). Instantiates one object from it.                          |
+| `list()`              | Maps a list of items to objects. Allows setting `$min`, `$max`, or exact `$count` constraints.                   |
+| `nullOrOne()`         | Same as `one()`, but allows the field to be optional (returns `null` if empty).                                  |
+| `Blocks()`            | Resolves a list of blocks using the `BlockRegistry`. Returns instances of block classes. Ignores unknown blocks. |
+| `enum()`              | Maps a string value to a backed enum. Supports default value and whitelisting of allowed values.                 |
+| `DateTimeImmutable()` | Returns a `Safe\DateTimeImmutable` object from a given date string.                                              |
+| `Uuid()`              | Returns a `Storyblok\Api\Domain\Value\Uuid` instance from a string.                                              |
+| `Asset()`             | Maps an asset array to a `Storyblok\Api\Domain\Type\Asset` object.                                               |
+| `nullOrAsset()`       | Same as `Asset()`, but allows null or invalid input.                                                             |
+| `MultiLink()`         | Maps a multilink array to a `Storyblok\Api\Domain\Type\MultiLink` object.                                        |
+| `nullOrMultiLink()`   | Same as `MultiLink()`, but returns `null` if `url` and `id` are missing or empty.                                |
+| `RichText()`          | Maps rich text content to a `Storyblok\Api\Domain\Type\RichText` object.                                         |
+| `nullOrRichText()`    | Same as `RichText()`, but returns `null` if content is empty or only contains whitespace.                        |
+| `boolean()`           | Returns `true` if the key exists and its value is `true`, otherwise `false`.                                     |
+| `zeroOrInteger()`     | Returns an integer from the field, or `0` if missing.                                                            |
+| `zeroOrFloat()`       | Returns a float from the field, or `0.0` if missing.                                                             |
+| `string()`            | Returns a trimmed non-empty string (using `TrimmedNonEmptyString`). Optional max length check.                   |
+| `nullOrString()`      | Same as `string()`, but returns `null` if missing or invalid.                                                    |
+| `nullOrEditable()`    | Returns an `Editable` instance or `null`.                                                                        |
 
 ## License
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,6 +31,12 @@ parameters:
 			path: src/DependencyInjection/StoryblokExtension.php
 
 		-
+			message: '#^Template type T of method Storyblok\\Bundle\\Tests\\Double\\Block\\BlockUsingHelperTrait\:\:Blocks\(\) is not referenced in a parameter\.$#'
+			identifier: method.templateTypeNotInParameter
+			count: 1
+			path: tests/Double/Block/BlockUsingHelperTrait.php
+
+		-
 			message: '#^Parameter \#2 \$className of class Storyblok\\Bundle\\Block\\BlockDefinition constructor expects class\-string, string given\.$#'
 			identifier: argument.type
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: src/DependencyInjection/StoryblokExtension.php
 
 		-
-			message: '#^Template type T of method Storyblok\\Bundle\\Tests\\Double\\Block\\BlockUsingHelperTrait\:\:Blocks\(\) is not referenced in a parameter\.$#'
-			identifier: method.templateTypeNotInParameter
-			count: 1
-			path: tests/Double/Block/BlockUsingHelperTrait.php
-
-		-
 			message: '#^Parameter \#2 \$className of class Storyblok\\Bundle\\Block\\BlockDefinition constructor expects class\-string, string given\.$#'
 			identifier: argument.type
 			count: 2

--- a/src/Util/HelperTrait.php
+++ b/src/Util/HelperTrait.php
@@ -367,12 +367,10 @@ trait HelperTrait
     }
 
     /**
-     * @template T of object
-     *
      * @param array<mixed>     $values
      * @param non-empty-string $key
      *
-     * @return list<T>
+     * @return list<object>
      */
     final protected static function Blocks(array $values, string $key, ?int $min = null, ?int $max = null, ?int $count = null): array
     {
@@ -406,9 +404,7 @@ trait HelperTrait
 
         foreach ($values[$key] as $value) {
             try {
-                /** @var T $block */
-                $block = new (BlockRegistry::byName($value['component'])->className)($value);
-                $blocks[] = $block;
+                $blocks[] = new (BlockRegistry::byName($value['component'])->className)($value);
             } catch (BlockNotFoundException) {
                 // Ignore the block if it is not found to not raise an exception and interrupt the construction.
             }

--- a/src/Util/HelperTrait.php
+++ b/src/Util/HelperTrait.php
@@ -406,7 +406,9 @@ trait HelperTrait
 
         foreach ($values[$key] as $value) {
             try {
-                $blocks[] = new (BlockRegistry::byName($value['component'])->className)($value);
+                /** @var T $block */
+                $block = new (BlockRegistry::byName($value['component'])->className)($value);
+                $blocks[] = $block;
             } catch (BlockNotFoundException) {
                 // Ignore the block if it is not found to not raise an exception and interrupt the construction.
             }

--- a/src/Util/HelperTrait.php
+++ b/src/Util/HelperTrait.php
@@ -1,0 +1,417 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Storyblok\Bundle\Util;
+
+use OskarStark\Value\TrimmedNonEmptyString;
+use Safe\DateTimeImmutable;
+use Storyblok\Api\Domain\Type\Asset;
+use Storyblok\Api\Domain\Type\Editable;
+use Storyblok\Api\Domain\Type\MultiLink;
+use Storyblok\Api\Domain\Type\RichText;
+use Storyblok\Api\Domain\Value\Uuid;
+use Storyblok\Bundle\Block\BlockRegistry;
+use Storyblok\Bundle\Block\Exception\BlockNotFoundException;
+use Tiptap\Editor;
+use Webmozart\Assert\Assert;
+
+trait HelperTrait
+{
+    /**
+     * @template T of object
+     *
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     * @param class-string<T>  $class
+     *
+     * @return T
+     */
+    final protected static function one(array $values, string $key, string $class): object
+    {
+        Assert::keyExists($values, $key);
+        Assert::isList($values[$key]);
+        Assert::count($values[$key], 1);
+
+        return new $class($values[$key][0]);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param array<mixed>    $values
+     * @param class-string<T> $class
+     *
+     * @return list<T>
+     */
+    final protected static function list(array $values, string $key, string $class, ?int $min = null, ?int $max = null, ?int $count = null): array
+    {
+        if (null !== $count && (null !== $min || null !== $max)) {
+            throw new \InvalidArgumentException('You can not use $count with $min or $max.');
+        }
+
+        if (null !== $count) {
+            Assert::keyExists($values, $key);
+            Assert::count($values[$key], $count);
+        }
+
+        if (null !== $min) {
+            Assert::keyExists($values, $key);
+            Assert::minCount($values[$key], $min);
+        } else {
+            if (!\array_key_exists($key, $values)) {
+                return [];
+            }
+        }
+
+        Assert::isList($values[$key]);
+
+        if (null !== $max) {
+            Assert::maxCount($values[$key], $max);
+        }
+
+        return array_map(static fn (array $item) => new $class($item), $values[$key]);
+    }
+
+    /**
+     * @template T of \BackedEnum
+     *
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     * @param class-string<T>  $class
+     * @param null|T           $default
+     * @param null|array<T>    $allowedSubset Only some cases of the enum that are allowed
+     *
+     * @return T
+     */
+    final protected static function enum(array $values, string $key, string $class, ?\BackedEnum $default = null, ?array $allowedSubset = null): \BackedEnum
+    {
+        Assert::keyExists($values, $key);
+
+        if (!enum_exists($class)) {
+            throw new \InvalidArgumentException(\sprintf('The class "%s" is not an enum.', $class));
+        }
+
+        try {
+            $enum = $class::from($values[$key]);
+
+            if (\is_array($allowedSubset)
+                && [] !== $allowedSubset
+            ) {
+                if (!method_exists($enum, 'equalsOneOf')) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'The enum "%s" does not have the method "equalsOneOf", but an allowed subset is defined.',
+                        $class,
+                    ));
+                }
+
+                Assert::true($enum->equalsOneOf($allowedSubset));
+            }
+
+            return $enum;
+        } catch (\ValueError $e) {
+            if (null !== $default) {
+                return $default;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function DateTimeImmutable(array $values, string $key, ?\DateTimeZone $timezone = null): DateTimeImmutable
+    {
+        Assert::keyExists($values, $key);
+
+        return new DateTimeImmutable($values[$key], $timezone);
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function Uuid(array $values, string $key): Uuid
+    {
+        return new Uuid(self::string($values, $key));
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function MultiLink(array $values, string $key): MultiLink
+    {
+        Assert::keyExists($values, $key);
+        Assert::isArray($values[$key]);
+
+        return new MultiLink($values[$key]);
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function Asset(array $values, string $key): Asset
+    {
+        Assert::keyExists($values, $key);
+        Assert::isArray($values[$key]);
+
+        return new Asset($values[$key]);
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function RichText(array $values, string $key): RichText
+    {
+        Assert::keyExists($values, $key);
+        Assert::isArray($values[$key]);
+
+        return new RichText($values[$key]);
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function nullOrRichText(array $values, string $key): ?RichText
+    {
+        $value = null;
+
+        if (\array_key_exists($key, $values)
+            && (null !== $values[$key] && [] !== $values[$key])
+        ) {
+            Assert::isArray($values[$key]);
+            $value = new RichText($values[$key]);
+
+            $text = \trim((new Editor())->setContent($value->toArray())->getText());
+
+            if ('' === $text) {
+                $value = null;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function zeroOrInteger(array $values, string $key): int
+    {
+        $value = 0;
+
+        if (\array_key_exists($key, $values)
+            && [] !== $values[$key]
+        ) {
+            $value = (int) $values[$key];
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function zeroOrFloat(array $values, string $key): float
+    {
+        $value = 0.0;
+
+        if (\array_key_exists($key, $values) && [] !== $values[$key]) {
+            $value = (float) $values[$key];
+        }
+
+        return $value;
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     * @param class-string<T>  $class
+     *
+     * @return null|T
+     */
+    final protected static function nullOrOne(array $values, string $key, string $class): ?object
+    {
+        if (\array_key_exists($key, $values)
+            && \count($values[$key]) > 0
+        ) {
+            Assert::count($values[$key], 1);
+            Assert::isList($values[$key]);
+
+            return new $class($values[$key][0]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function boolean(array $values, string $key): bool
+    {
+        $value = false;
+
+        if (\array_key_exists($key, $values)) {
+            $value = true === $values[$key];
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function nullOrAsset(array $values, string $key): ?Asset
+    {
+        if (!\array_key_exists($key, $values)) {
+            return null;
+        }
+
+        try {
+            return new Asset($values[$key]);
+        } catch (\InvalidArgumentException|\TypeError) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function nullOrMultiLink(array $values, string $key): ?MultiLink
+    {
+        if (!\array_key_exists($key, $values)) {
+            return null;
+        }
+
+        $linkValues = $values[$key];
+
+        // If the link url and id are empty, we return null
+        if ((!isset($linkValues['url']) || '' === trim($linkValues['url']))
+            && (!isset($linkValues['id']) || '' === trim($linkValues['id']))
+        ) {
+            return null;
+        }
+
+        try {
+            return new MultiLink($linkValues);
+        } catch (\InvalidArgumentException|\TypeError) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns null if the value is not set or a trimmed non-empty string.
+     *
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function nullOrString(array $values, string $key): ?string
+    {
+        if (!\array_key_exists($key, $values)) {
+            return null;
+        }
+
+        try {
+            return TrimmedNonEmptyString::from($values[$key])->toString();
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns a trimmed non-empty string.
+     *
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function string(array $values, string $key, ?int $maxLength = null): string
+    {
+        Assert::keyExists($values, $key);
+
+        if (null !== $maxLength) {
+            Assert::maxLength($values[$key], $maxLength);
+        }
+
+        return TrimmedNonEmptyString::fromString($values[$key])->toString();
+    }
+
+    /**
+     * Returns null if the value is not set or an Editable.
+     *
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     */
+    final protected static function nullOrEditable(array $values, string $key): ?Editable
+    {
+        if (!\array_key_exists($key, $values)) {
+            return null;
+        }
+
+        try {
+            return new Editable($values[$key]);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param array<mixed>     $values
+     * @param non-empty-string $key
+     *
+     * @return list<T>
+     */
+    final protected static function Blocks(array $values, string $key, ?int $min = null, ?int $max = null, ?int $count = null): array
+    {
+        if (null !== $count && (null !== $min || null !== $max)) {
+            throw new \InvalidArgumentException('You can not use $count with $min or $max.');
+        }
+
+        if (null !== $count) {
+            Assert::keyExists($values, $key);
+            Assert::count($values[$key], $count);
+        }
+
+        if (null !== $min) {
+            Assert::keyExists($values, $key);
+            Assert::minCount($values[$key], $min);
+        } else {
+            if (!\array_key_exists($key, $values)) {
+                return [];
+            }
+        }
+
+        Assert::isList($values[$key]);
+
+        if (null !== $max) {
+            Assert::maxCount($values[$key], $max);
+        }
+
+        Assert::allKeyExists($values[$key], 'component');
+
+        $blocks = [];
+
+        foreach ($values[$key] as $value) {
+            try {
+                $blocks[] = new (BlockRegistry::byName($value['component'])->className)($value);
+            } catch (BlockNotFoundException) {
+                // Ignore the block if it is not found to not raise an exception and interrupt the construction.
+            }
+        }
+
+        return $blocks;
+    }
+}

--- a/tests/Double/Block/BlockUsingHelperTrait.php
+++ b/tests/Double/Block/BlockUsingHelperTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/symfony-bundle.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Double\Block;
+
+use Storyblok\Api\Domain\Type\Asset;
+use Storyblok\Api\Domain\Type\MultiLink;
+use Storyblok\Api\Domain\Type\RichText;
+use Storyblok\Bundle\Block\Attribute\AsBlock;
+use Storyblok\Bundle\Util\HelperTrait;
+
+#[AsBlock]
+final readonly class BlockUsingHelperTrait
+{
+    use HelperTrait;
+
+    public string $title;
+    public ?string $description;
+    public Asset $image;
+    public MultiLink $link;
+
+    /**
+     * @var list<object>
+     */
+    public array $blocks;
+
+    public RichText $content;
+    public ?object $button;
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public function __construct(array $values)
+    {
+        $this->title = self::string($values, 'title');
+        $this->description = self::nullOrString($values, 'description');
+        $this->image = self::Asset($values, 'image');
+        $this->link = self::MultiLink($values, 'link');
+        $this->blocks = self::Blocks($values, 'blocks');
+        $this->content = self::RichText($values, 'content');
+        $this->button = self::nullOrOne($values, 'button', \stdClass::class);
+    }
+}


### PR DESCRIPTION
This PR introduces a new `HelperTrait`  under `Storyblok\Bundle\Util`, providing a set of reusable methods to streamline the parsing and validation of raw Storyblok API response data.

The trait helps reduce boilerplate when building DTOs by offering common transformation helpers (e.g. `one()`, `list()`, `enum()`, `RichText()`, `MultiLink()`, etc.), with built-in handling for missing or malformed input.

This addition enhances developer experience when working with complex Storyblok schemas and improves overall code safety and readability.