### PR TITLE
feat(routes): Allow `_` for `storyblok_content_type` route

### DIFF
--- a/config/routes/content_type.php
+++ b/config/routes/content_type.php
@@ -18,10 +18,10 @@ return function (RoutingConfigurator $routes): void {
              *  \p{L} → Matches any letter (Latin, Kanji, Hiragana, Katakana, etc.)
              *  \p{N} → Matches any number (so numbers remain valid in slugs)
              *  (?:-[\p{L}\p{N}]+)* → Allows hyphenated words (e.g., hello-world)
-             *  (?:\/[\p{L}\p{N}]+(?:-[\p{L}\p{N}]+)*)*\/? → Allows slashes for hierarchical paths
+             *  (?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/? → Allows slashes for hierarchical paths
              *  Trailing slash (\/?) → Optional to allow both /slug and /slug/.
              */
-            'slug' => '([\p{L}\p{N}]+(?:-[\p{L}\p{N}]+)*(?:\/[\p{L}\p{N}]+(?:-[\p{L}\p{N}]+)*)*\/?)$',
+            'slug' => '([\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*(?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/?)$',
         ])
         ->options([
             'priority' => -10000,

--- a/config/routes/content_type.php
+++ b/config/routes/content_type.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\Routing\Loader\Configurator;
 
 use Storyblok\Bundle\ContentType\Listener\ResolveControllerListener;
+use Storyblok\Bundle\Routing\Requirement;
 use Storyblok\Bundle\Routing\Route;
 
 return function (RoutingConfigurator $routes): void {
@@ -14,14 +15,7 @@ return function (RoutingConfigurator $routes): void {
          */
         ->controller(\sprintf('%s::noop', ResolveControllerListener::class))
         ->requirements([
-            /**
-             *  \p{L} → Matches any letter (Latin, Kanji, Hiragana, Katakana, etc.)
-             *  \p{N} → Matches any number (so numbers remain valid in slugs)
-             *  (?:-[\p{L}\p{N}]+)* → Allows hyphenated words (e.g., hello-world)
-             *  (?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/? → Allows slashes for hierarchical paths
-             *  Trailing slash (\/?) → Optional to allow both /slug and /slug/.
-             */
-            'slug' => '([\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*(?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/?)$',
+            'slug' => Requirement::SLUG,
         ])
         ->options([
             'priority' => -10000,

--- a/src/Routing/Requirement.php
+++ b/src/Routing/Requirement.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/symfony-bundle.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Routing;
+
+enum Requirement
+{
+    /**
+     *  \p{L} → Matches any letter (Latin, Kanji, Hiragana, Katakana, etc.)
+     *  \p{N} → Matches any number (so numbers remain valid in slugs)
+     *  (?:-[\p{L}\p{N}]+)* → Allows hyphenated words (e.g., hello-world)
+     *  (?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/? → Allows slashes for hierarchical paths
+     *  Trailing slash (\/?) → Optional to allow both /slug and /slug/.
+     */
+    public const string SLUG = '([\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*(?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/?)$';
+}

--- a/src/Routing/Requirement.php
+++ b/src/Routing/Requirement.php
@@ -16,6 +16,7 @@ namespace Storyblok\Bundle\Routing;
 
 /**
  * @author Silas Joisten <silasjoisten@proton.me>
+ * @author Kristian Hempel <protykhybrid@googlemail.com>
  */
 enum Requirement
 {

--- a/src/Routing/Requirement.php
+++ b/src/Routing/Requirement.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace Storyblok\Bundle\Routing;
 
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
 enum Requirement
 {
     /**

--- a/tests/Unit/Routing/RequirementTest.php
+++ b/tests/Unit/Routing/RequirementTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/symfony-bundle.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Bundle\Tests\Unit\Routing;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Storyblok\Bundle\Routing\Requirement;
+
+final class RequirementTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('slugs')]
+    public function slugRegexMatches(string $value): void
+    {
+        self::assertMatchesRegularExpression(\sprintf('/%s/u', Requirement::SLUG), $value);
+    }
+
+    /**
+     * @return iterable<string, string[]>
+     */
+    public static function slugs(): iterable
+    {
+        yield 'dash' => ['valid-slug'];
+        yield 'underscore' => ['valid_slug'];
+        yield 'complete path with underscores' => ['my/path_to/a_valid_slug'];
+        yield 'complete path with dashes' => ['my/path-to/a-valid-slug'];
+        yield 'with trailing slash' => ['my/test/'];
+        yield 'with leading slash' => ['/my/test'];
+        yield 'cyrillic characters' => ['тест/привіт-світ'];
+        yield 'japanese characters' => ['こんにちは世界'];
+    }
+}

--- a/tests/Unit/Routing/RequirementTest.php
+++ b/tests/Unit/Routing/RequirementTest.php
@@ -25,7 +25,7 @@ final class RequirementTest extends TestCase
     #[DataProvider('slugs')]
     public function slugRegexMatches(string $value): void
     {
-        self::assertMatchesRegularExpression(\sprintf('/%s/u', Requirement::SLUG), $value);
+        self::assertMatchesRegularExpression(\sprintf('#%s#u', Requirement::SLUG), $value);
     }
 
     /**
@@ -34,7 +34,9 @@ final class RequirementTest extends TestCase
     public static function slugs(): iterable
     {
         yield 'dash' => ['valid-slug'];
+        yield 'only dash' => ['/-/test'];
         yield 'underscore' => ['valid_slug'];
+        yield 'only underscore' => ['/_/test'];
         yield 'complete path with underscores' => ['my/path_to/a_valid_slug'];
         yield 'complete path with dashes' => ['my/path-to/a-valid-slug'];
         yield 'with trailing slash' => ['my/test/'];


### PR DESCRIPTION
Regarding to the FAQ's storyblok allows also `_` 

https://www.storyblok.com/faq/what-characters-are-permissible-for-content-entry-slugs#:~:text=By%20default%2C%20the%20following%20characters,underscore%20(%20_%20)

Feature request of @KristianH

<img width="3016" height="1580" alt="CleanShot 2025-07-12 at 11 35 14@2x" src="https://github.com/user-attachments/assets/e9927c0e-8af3-4f90-93c5-f6d22fa432a2" />
