### PR TITLE
bc(cache): Replace smax_age with private deprecation with exception

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -64,6 +64,45 @@ Ensure that the value passed to `rich_text` is a **Rich Text object**, not an ar
 
 ---
 
+### 3. `smax_age` with `public: false` Now Throws an Exception
+
+Setting `smax_age` with `public: false` in `storyblok.controller.cache` or `storyblok.cdn.cache` now throws an `InvalidConfigurationException` instead of triggering a deprecation warning.
+
+```yaml
+# ❌ This configuration is no longer allowed
+storyblok:
+    controller:
+        cache:
+            public: false
+            smax_age: 3600
+```
+
+#### 🔧 How to upgrade:
+
+The `s-maxage` directive is only applicable to shared caches (CDN/proxy), which require public caching. Either:
+
+1. **Remove `smax_age`** if you want private caching:
+   ```yaml
+   storyblok:
+       controller:
+           cache:
+               public: false
+               max_age: 3600
+   ```
+
+2. **Use `public: true`** (or remove it) if you want shared cache caching:
+   ```yaml
+   storyblok:
+       controller:
+           cache:
+               public: true
+               smax_age: 3600
+   ```
+
+> 📝 This was deprecated in version `1.16.0`.
+
+---
+
 ## 🧪 Run the Symfony Deprecation Detector
 
 Run this command to see what needs to be updated before upgrading:
@@ -72,13 +111,13 @@ Run this command to see what needs to be updated before upgrading:
 bin/console debug:container --deprecations
 ```
 
-Make sure to address any deprecation notices introduced in `1.10.0`.
+Make sure to address any deprecation notices introduced in `1.10.0` and `1.16.0`.
 
 ---
 
 ## ✅ Recommended Steps
 
-1. Upgrade to the latest `1.10.x` version.
+1. Upgrade to the latest `1.x` version.
 2. Fix all deprecation warnings.
 3. Update your code to follow the new interface and filter requirements.
 4. Require `storyblok/symfony-bundle:^2.0` in your `composer.json`.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,28 +7,10 @@ parameters:
 			path: src/Block/BlockDefinition.php
 
 		-
-			message: '#^Method Storyblok\\Bundle\\Block\\Renderer\\BlockRenderer\:\:render\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Block/Renderer/BlockRenderer.php
-
-		-
-			message: '#^PHPDoc tag @param references unknown parameter\: \$context$#'
-			identifier: parameter.notFound
-			count: 1
-			path: src/Block/Renderer/RendererInterface.php
-
-		-
 			message: '#^Method Storyblok\\Bundle\\DataCollector\\StoryblokCollector\:\:collectOnClient\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/DataCollector/StoryblokCollector.php
-
-		-
-			message: '#^Method Storyblok\\Bundle\\DependencyInjection\\Configuration\:\:getConfigTreeBuilder\(\) return type with generic class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/DependencyInjection/Configuration.php
 
 		-
 			message: '#^Parameter \#2 \$configurator of method Symfony\\Component\\DependencyInjection\\ContainerBuilder\:\:registerAttributeForAutoconfiguration\(\) expects callable\(Symfony\\Component\\DependencyInjection\\ChildDefinition, Storyblok\\Bundle\\Block\\Attribute\\AsBlock, Reflector\)\: void, Closure\(Symfony\\Component\\DependencyInjection\\ChildDefinition, Storyblok\\Bundle\\Block\\Attribute\\AsBlock, ReflectionClass\)\: void given\.$#'

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -88,15 +88,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->validate()
                                 ->ifTrue(static fn (array $v): bool => false === $v['public'] && null !== $v['smax_age'])
-                                ->then(static function (array $v): array {
-                                    trigger_deprecation(
-                                        'storyblok/symfony-bundle',
-                                        '1.16.0',
-                                        'Setting "smax_age" with "public: false" in "storyblok.controller.cache" is deprecated. The s-maxage directive is only applicable to shared caches (CDN/proxy), which require public caching. This configuration will throw an exception in 2.0.',
-                                    );
-
-                                    return $v;
-                                })
+                                ->thenInvalid('Setting "smax_age" with "public: false" is not allowed. The s-maxage directive is only applicable to shared caches (CDN/proxy), which require public caching.')
                             ->end()
                         ->end()
                     ->end()
@@ -149,15 +141,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->validate()
                                 ->ifTrue(static fn (array $v): bool => false === $v['public'] && null !== $v['smax_age'])
-                                ->then(static function (array $v): array {
-                                    trigger_deprecation(
-                                        'storyblok/symfony-bundle',
-                                        '1.16.0',
-                                        'Setting "smax_age" with "public: false" in "storyblok.cdn.cache" is deprecated. The s-maxage directive is only applicable to shared caches (CDN/proxy), which require public caching. This configuration will throw an exception in 2.0.',
-                                    );
-
-                                    return $v;
-                                })
+                                ->thenInvalid('Setting "smax_age" with "public: false" is not allowed. The s-maxage directive is only applicable to shared caches (CDN/proxy), which require public caching.')
                             ->end()
                         ->end()
                     ->end()

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -40,7 +40,6 @@ final class ConfigurationTest extends TestCase
         $public = $faker->boolean();
         $cdnMaxAge = $faker->numberBetween(3600);
         $cdnSmaxAge = $faker->numberBetween(3600);
-        $cdnPublic = $faker->boolean();
 
         self::assertProcessedConfigurationEquals([
             ['base_uri' => $url],
@@ -67,7 +66,7 @@ final class ConfigurationTest extends TestCase
                         'path' => '/custom/cdn/path',
                     ],
                     'cache' => [
-                        'public' => $cdnPublic,
+                        'public' => true,
                         'max_age' => $cdnMaxAge,
                         'smax_age' => $cdnSmaxAge,
                     ],
@@ -98,7 +97,7 @@ final class ConfigurationTest extends TestCase
                     'path' => '/custom/cdn/path',
                 ],
                 'cache' => [
-                    'public' => $cdnPublic,
+                    'public' => true,
                     'max_age' => $cdnMaxAge,
                     'smax_age' => $cdnSmaxAge,
                 ],

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -455,95 +455,37 @@ final class ConfigurationTest extends TestCase
     }
 
     #[Test]
-    public function controllerCacheSmaxAgeWithPrivateTriggersDeprecation(): void
+    public function controllerCacheSmaxAgeWithPrivateIsInvalid(): void
     {
         $faker = self::faker();
         $url = $faker->url();
         $token = $faker->uuid();
 
-        $this->expectUserDeprecationMessage('Since storyblok/symfony-bundle 1.16.0: Setting "smax_age" with "public: false" in "storyblok.controller.cache" is deprecated. The s-maxage directive is only applicable to shared caches (CDN/proxy), which require public caching. This configuration will throw an exception in 2.0.');
-
-        self::assertProcessedConfigurationEquals([
-            ['base_uri' => $url],
-            ['token' => $token],
-            ['controller' => ['cache' => ['public' => false, 'smax_age' => 3600]]],
-        ], [
-            'base_uri' => $url,
-            'token' => $token,
-            'webhook_secret' => null,
-            'version' => 'published',
-            'auto_resolve_relations' => false,
-            'auto_resolve_links' => false,
-            'blocks_template_path' => 'blocks',
-            'controller' => [
-                'ascending_redirect_fallback' => false,
-                'cache' => [
-                    'public' => false,
-                    'must_revalidate' => null,
-                    'etag' => null,
-                    'max_age' => null,
-                    'smax_age' => 3600,
-                ],
+        self::assertConfigurationIsInvalid(
+            [
+                ['base_uri' => $url],
+                ['token' => $token],
+                ['controller' => ['cache' => ['public' => false, 'smax_age' => 3600]]],
             ],
-            'cdn' => [
-                'enabled' => true,
-                'storage' => [
-                    'type' => 'filesystem',
-                    'path' => '%kernel.project_dir%/var/cdn',
-                ],
-                'cache' => [
-                    'public' => null,
-                    'max_age' => null,
-                    'smax_age' => null,
-                ],
-            ],
-        ]);
+            'Setting "smax_age" with "public: false" is not allowed.',
+        );
     }
 
     #[Test]
-    public function cdnCacheSmaxAgeWithPrivateTriggersDeprecation(): void
+    public function cdnCacheSmaxAgeWithPrivateIsInvalid(): void
     {
         $faker = self::faker();
         $url = $faker->url();
         $token = $faker->uuid();
 
-        $this->expectUserDeprecationMessage('Since storyblok/symfony-bundle 1.16.0: Setting "smax_age" with "public: false" in "storyblok.cdn.cache" is deprecated. The s-maxage directive is only applicable to shared caches (CDN/proxy), which require public caching. This configuration will throw an exception in 2.0.');
-
-        self::assertProcessedConfigurationEquals([
-            ['base_uri' => $url],
-            ['token' => $token],
-            ['cdn' => ['cache' => ['public' => false, 'smax_age' => 3600]]],
-        ], [
-            'base_uri' => $url,
-            'token' => $token,
-            'webhook_secret' => null,
-            'version' => 'published',
-            'auto_resolve_relations' => false,
-            'auto_resolve_links' => false,
-            'blocks_template_path' => 'blocks',
-            'controller' => [
-                'ascending_redirect_fallback' => false,
-                'cache' => [
-                    'public' => null,
-                    'must_revalidate' => null,
-                    'etag' => null,
-                    'max_age' => null,
-                    'smax_age' => null,
-                ],
+        self::assertConfigurationIsInvalid(
+            [
+                ['base_uri' => $url],
+                ['token' => $token],
+                ['cdn' => ['cache' => ['public' => false, 'smax_age' => 3600]]],
             ],
-            'cdn' => [
-                'enabled' => true,
-                'storage' => [
-                    'type' => 'filesystem',
-                    'path' => '%kernel.project_dir%/var/cdn',
-                ],
-                'cache' => [
-                    'public' => false,
-                    'max_age' => null,
-                    'smax_age' => 3600,
-                ],
-            ],
-        ]);
+            'Setting "smax_age" with "public: false" is not allowed.',
+        );
     }
 
     protected function getConfiguration(): Configuration

--- a/tests/Unit/DependencyInjection/StoryblokExtensionTest.php
+++ b/tests/Unit/DependencyInjection/StoryblokExtensionTest.php
@@ -306,7 +306,6 @@ final class StoryblokExtensionTest extends TestCase
         $builder = new ContainerBuilder();
         $builder->setParameter('kernel.debug', true);
 
-        $cdnPublic = $faker->boolean();
         $cdnMaxAge = $faker->numberBetween(3600, 86400);
         $cdnSmaxAge = $faker->numberBetween(3600, 86400);
 
@@ -316,7 +315,7 @@ final class StoryblokExtensionTest extends TestCase
             [
                 'cdn' => [
                     'cache' => [
-                        'public' => $cdnPublic,
+                        'public' => true,
                         'max_age' => $cdnMaxAge,
                         'smax_age' => $cdnSmaxAge,
                     ],
@@ -332,7 +331,7 @@ final class StoryblokExtensionTest extends TestCase
         $definition = $builder->getDefinition(CdnController::class);
         $arguments = $definition->getArguments();
 
-        self::assertSame($cdnPublic, $arguments['$public']);
+        self::assertTrue($arguments['$public']);
         self::assertSame($cdnMaxAge, $arguments['$maxAge']);
         self::assertSame($cdnSmaxAge, $arguments['$smaxAge']);
     }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Setting `smax_age` with `public: false` in `storyblok.controller.cache` or `storyblok.cdn.cache` now throws an `InvalidConfigurationException` instead of triggering a deprecation warning.

The `s-maxage` directive is only applicable to shared caches (CDN/proxy), which require public caching. This invalid configuration combination was deprecated in 1.16.0 and is now disallowed in 2.0.

## Changes

- Replace `trigger_deprecation()` with `thenInvalid()` validation in Configuration.php
- Update tests to expect invalid configuration exception
- Update UPGRADE-2.0.md with migration instructions