### PR TITLE
feat(cdn): Add cache validation support for CDN controller

### DIFF
--- a/src/Controller/CdnController.php
+++ b/src/Controller/CdnController.php
@@ -20,6 +20,7 @@ use Storyblok\Bundle\Cdn\Storage\CdnFileNotFoundException;
 use Storyblok\Bundle\Cdn\Storage\CdnStorageInterface;
 use Storyblok\Bundle\Cdn\Storage\MetadataNotFoundException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -39,7 +40,7 @@ final readonly class CdnController
     ) {
     }
 
-    public function __invoke(string $id, string $filename, string $extension): Response
+    public function __invoke(Request $request, string $id, string $filename, string $extension): Response
     {
         $fileId = new CdnFileId($id);
         $fullFilename = \sprintf('%s.%s', $filename, $extension);
@@ -97,6 +98,8 @@ final readonly class CdnController
                 $response->setPrivate();
             }
         }
+
+        $response->isNotModified($request);
 
         return $response;
     }


### PR DESCRIPTION
## Summary

- Adds `Request` parameter to `CdnController::__invoke()` for cache validation
- Calls `Response::isNotModified()` to return 304 Not Modified responses when client sends matching `If-None-Match` header
- ETag is already set from downloaded file metadata, this change enables the validation

## Changes

- Updated `CdnController` to accept `Request` parameter
- Added `isNotModified($request)` call before returning response
- Updated all tests to pass `Request` object
- Added test for 304 Not Modified response
