### PR TITLE
fix: double underscore route not resolved

### DIFF
--- a/src/Routing/Requirement.php
+++ b/src/Routing/Requirement.php
@@ -27,5 +27,5 @@ enum Requirement
      *  (?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/? → Allows slashes for hierarchical paths
      *  Trailing slash (\/?) → Optional to allow both /slug and /slug/.
      */
-    public const string SLUG = '([/_-]/)?([\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*(?:\/[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)*)*\/?)$';
+    public const string SLUG = '([/_-]/)?([\p{L}\p{N}]+(?:[-_]+[\p{L}\p{N}]+)*(?:\/[\p{L}\p{N}]+(?:[-_]+[\p{L}\p{N}]+)*)*\/?)$';
 }

--- a/tests/Unit/Routing/RequirementTest.php
+++ b/tests/Unit/Routing/RequirementTest.php
@@ -36,6 +36,7 @@ final class RequirementTest extends TestCase
         yield 'dash' => ['valid-slug'];
         yield 'only dash' => ['/-/test'];
         yield 'underscore' => ['valid_slug'];
+        yield 'double underscore' => ['valid_slug-with__double-underscore-v1'];
         yield 'only underscore' => ['/_/test'];
         yield 'complete path with underscores' => ['my/path_to/a_valid_slug'];
         yield 'complete path with dashes' => ['my/path-to/a-valid-slug'];


### PR DESCRIPTION
Fixes: #115 

What have I done:

- modified the slug regex to allow double underscores


Why was this done:

- the new a/b testing feature auto generates urls with double underscores leading to errors

How to test it:

- enable experiments in the StoryBlok space
- create a new A/B test for a page
- switch to the alternative content in the visual editor
- the page should render correctly