### PR TITLE
fix: strip language prefix from full_slug when Translatable Slugs app is not installed

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,7 +57,7 @@ parameters:
 		-
 			message: '#^Cannot access constant class on callable\.$#'
 			identifier: classConstant.nonObject
-			count: 10
+			count: 11
 			path: tests/Unit/ContentType/Listener/ResolveControllerListenerTest.php
 
 		-

--- a/src/ContentType/Listener/ResolveControllerListener.php
+++ b/src/ContentType/Listener/ResolveControllerListener.php
@@ -77,6 +77,18 @@ final readonly class ResolveControllerListener
             Assert::keyExists($story, 'full_slug');
             $slug = $story['default_full_slug'] ?? $story['full_slug'];
 
+            // Without the Translatable Slugs app "default_full_slug" is null and
+            // "full_slug" is prefixed with the requested language ("en/about-us").
+            // The Content Delivery API only accepts the unprefixed slug, so the
+            // prefix must be removed before the slug is used for further requests.
+            if (null === $story['default_full_slug']
+                && \is_string($story['lang'] ?? null)
+                && 'default' !== $story['lang']
+                && \str_starts_with($slug, $story['lang'].'/')
+            ) {
+                $slug = \substr($slug, \strlen($story['lang']) + 1);
+            }
+
             Assert::keyExists($story, 'content');
             Assert::keyExists($story['content'], 'component');
         } catch (ClientExceptionInterface|\InvalidArgumentException|\ValueError) {

--- a/tests/Unit/ContentType/Listener/ResolveControllerListenerTest.php
+++ b/tests/Unit/ContentType/Listener/ResolveControllerListenerTest.php
@@ -50,7 +50,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesController(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -95,7 +95,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesControllerBySlug(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -142,7 +142,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesControllerBySlugWithoutLocalizedSlugAppInstalled(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -186,10 +186,74 @@ final class ResolveControllerListenerTest extends TestCase
     }
 
     #[Test]
+    public function resolvesControllerWithLanguagePrefixedFullSlugWithoutLocalizedSlugAppInstalled(): void
+    {
+        $response = new StoryResponse([
+            'story' => [
+                'content' => [
+                    'component' => SampleContentType::type(),
+                ],
+                'default_full_slug' => null,
+                'full_slug' => 'en/'.SampleWithSlugController::SLUG,
+                'lang' => 'en',
+            ],
+            'cv' => 0,
+            'rels' => [],
+            'links' => [],
+        ]);
+
+        $slugs = [];
+
+        $api = self::createMock(StoriesApiInterface::class);
+        $api->expects($this->exactly(2))
+            ->method('bySlug')
+            ->willReturnCallback(static function (string $slug) use (&$slugs, $response): StoryResponse {
+                $slugs[] = $slug;
+
+                return $response;
+            });
+
+        $container = new Container();
+        $container->set(SampleController::class, new SampleController());
+        $container->set(SampleWithSlugController::class, new SampleWithSlugController());
+
+        $registry = new ContentTypeControllerRegistry();
+        $registry->add(new ContentTypeControllerDefinition(SampleController::class, SampleContentType::class, 'sample_content_type'));
+        $registry->add(new ContentTypeControllerDefinition(
+            SampleWithSlugController::class,
+            SampleContentType::class,
+            'sample_content_type',
+            '/'.SampleWithSlugController::SLUG,
+            resolveLinks: new ResolveLinks(type: LinkType::Link),
+        ));
+
+        $storage = new ContentTypeStorage();
+
+        $listener = new ResolveControllerListener($api, $container, $registry, $storage, new NullLogger(), 'draft');
+
+        $request = new Request();
+        $request->setLocale('en');
+        $request->attributes->set('_route', Route::CONTENT_TYPE);
+        $request->attributes->set('_route_params', ['slug' => SampleWithSlugController::SLUG]);
+
+        $listener($event = new ControllerEvent(
+            TestKernel::create([], self::class, static fn () => ''),
+            static fn () => '',
+            $request,
+            KernelInterface::MAIN_REQUEST,
+        ));
+
+        self::assertSame([\rtrim(SampleWithSlugController::SLUG, '/'), SampleWithSlugController::SLUG], $slugs);
+        self::assertSame(SampleWithSlugController::class, $event->getController()::class);
+        self::assertSame(SampleContentType::class, $request->attributes->get('_storyblok_content_type'));
+        self::assertNotNull($storage->getContentType());
+    }
+
+    #[Test]
     public function isNotMainRequest(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::never())
+        $api->expects($this->never())
             ->method('bySlug');
 
         $listener = new ResolveControllerListener($api, new Container(), new ContentTypeControllerRegistry(), $storage = new ContentTypeStorage(), new NullLogger(), 'draft');
@@ -210,7 +274,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function routeAttributeIsNotContentTypeRoute(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::never())
+        $api->expects($this->never())
             ->method('bySlug');
 
         $listener = new ResolveControllerListener($api, new Container(), new ContentTypeControllerRegistry(), $storage = new ContentTypeStorage(), new NullLogger(), 'draft');
@@ -234,7 +298,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function routeParamsAttributeHasNoSlug(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::never())
+        $api->expects($this->never())
             ->method('bySlug');
 
         $listener = new ResolveControllerListener($api, new Container(), new ContentTypeControllerRegistry(), $storage = new ContentTypeStorage(), new NullLogger(), 'draft');
@@ -259,7 +323,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function bySlugThrowsException(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('bySlug')
             ->willThrowException(new \InvalidArgumentException());
 
@@ -283,7 +347,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesControllerThrowsInvalidStoryExceptionWhenContentTypeCanNotBeConstructed(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -335,7 +399,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesControllerWithResolveRelations(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::exactly(2))
+        $api->expects($this->exactly(2))
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -386,7 +450,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesControllerWithResolveLinks(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::exactly(2))
+        $api->expects($this->exactly(2))
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -438,7 +502,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesControllerWithResolveRelationsAndResolveLinks(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::exactly(2))
+        $api->expects($this->exactly(2))
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -490,7 +554,7 @@ final class ResolveControllerListenerTest extends TestCase
     public function resolvesControllerWithoutResolveRelationsAndResolveLinksCallsApiOnce(): void
     {
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::once())
+        $api->expects($this->once())
             ->method('bySlug')
             ->willReturn(new StoryResponse([
                 'story' => [
@@ -543,7 +607,7 @@ final class ResolveControllerListenerTest extends TestCase
     {
         $callCount = 0;
         $api = self::createMock(StoriesApiInterface::class);
-        $api->expects(self::exactly(2))
+        $api->expects($this->exactly(2))
             ->method('bySlug')
             ->willReturnCallback(static function () use (&$callCount): StoryResponse {
                 ++$callCount;

--- a/tests/Unit/ContentType/Listener/ResolveControllerListenerTest.php
+++ b/tests/Unit/ContentType/Listener/ResolveControllerListenerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Storyblok\Bundle\Tests\Unit\ContentType\Listener;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -247,6 +248,119 @@ final class ResolveControllerListenerTest extends TestCase
         self::assertSame(SampleWithSlugController::class, $event->getController()::class);
         self::assertSame(SampleContentType::class, $request->attributes->get('_storyblok_content_type'));
         self::assertNotNull($storage->getContentType());
+    }
+
+    /**
+     * @param array<string, mixed> $story
+     */
+    #[DataProvider('provideStorySlugCases')]
+    #[Test]
+    public function usesCorrectSlugForSecondFetch(string $expectedSlug, array $story): void
+    {
+        $response = new StoryResponse([
+            'story' => [
+                'content' => [
+                    'component' => SampleContentType::type(),
+                ],
+                ...$story,
+            ],
+            'cv' => 0,
+            'rels' => [],
+            'links' => [],
+        ]);
+
+        $slugs = [];
+
+        $api = self::createMock(StoriesApiInterface::class);
+        $api->expects($this->exactly(2))
+            ->method('bySlug')
+            ->willReturnCallback(static function (string $slug) use (&$slugs, $response): StoryResponse {
+                $slugs[] = $slug;
+
+                return $response;
+            });
+
+        $container = new Container();
+        $container->set(SampleController::class, new SampleController());
+
+        $registry = new ContentTypeControllerRegistry();
+        $registry->add(new ContentTypeControllerDefinition(
+            SampleController::class,
+            SampleContentType::class,
+            'sample_content_type',
+            resolveLinks: new ResolveLinks(type: LinkType::Link),
+        ));
+
+        $storage = new ContentTypeStorage();
+
+        $listener = new ResolveControllerListener($api, $container, $registry, $storage, new NullLogger(), 'draft');
+
+        $request = new Request();
+        $request->attributes->set('_route', Route::CONTENT_TYPE);
+        $request->attributes->set('_route_params', ['slug' => 'requested-slug']);
+
+        $listener(new ControllerEvent(
+            TestKernel::create([], self::class, static fn () => ''),
+            static fn () => '',
+            $request,
+            KernelInterface::MAIN_REQUEST,
+        ));
+
+        self::assertSame(['requested-slug', $expectedSlug], $slugs);
+        self::assertNotNull($storage->getContentType());
+    }
+
+    /**
+     * @return iterable<string, array{string, array<string, mixed>}>
+     */
+    public static function provideStorySlugCases(): iterable
+    {
+        yield 'translatable slugs app installed, default language' => ['about-us', [
+            'default_full_slug' => 'about-us',
+            'full_slug' => 'about-us',
+            'lang' => 'default',
+        ]];
+
+        yield 'translatable slugs app installed, language prefixed full_slug' => ['about-us', [
+            'default_full_slug' => 'about-us',
+            'full_slug' => 'en/ueber-uns',
+            'lang' => 'en',
+        ]];
+
+        yield 'no translatable slugs app, default language' => ['about-us', [
+            'default_full_slug' => null,
+            'full_slug' => 'about-us',
+            'lang' => 'default',
+        ]];
+
+        yield 'no translatable slugs app, language prefixed full_slug' => ['about-us', [
+            'default_full_slug' => null,
+            'full_slug' => 'en/about-us',
+            'lang' => 'en',
+        ]];
+
+        yield 'no translatable slugs app, language prefixed nested full_slug' => ['folder/about-us', [
+            'default_full_slug' => null,
+            'full_slug' => 'en/folder/about-us',
+            'lang' => 'en',
+        ]];
+
+        yield 'no translatable slugs app, unprefixed full_slug for non-default language' => ['about-us', [
+            'default_full_slug' => null,
+            'full_slug' => 'about-us',
+            'lang' => 'en',
+        ]];
+
+        yield 'no translatable slugs app, slug segment equals language code' => ['en/en-page', [
+            'default_full_slug' => 'en/en-page',
+            'full_slug' => 'en/en-page',
+            'lang' => 'default',
+        ]];
+
+        yield 'no translatable slugs app, missing lang key' => ['about-us', [
+            'default_full_slug' => null,
+            'full_slug' => 'about-us',
+        ]];
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

When a story is fetched with the `?language=` parameter and the **Translatable Slugs** app is *not* installed in the space, the Content Delivery API returns:

- `default_full_slug`: `null`
- `full_slug`: prefixed with the requested language, e.g. `en/about-us`

`ResolveControllerListener` uses `$story['default_full_slug'] ?? $story['full_slug']` and feeds that slug back into `StoriesApi::bySlug()` for its second fetch (when the controller declares `resolveRelations`/`resolveLinks`) and into the controller registry slug lookup. The API does not know the language-prefixed slug and responds with 404 — so **every non-default-locale page whose controller declares `resolveRelations` or `resolveLinks` throws a `StoryNotFoundException`**, while the default locale keeps working (its `full_slug` is never prefixed).

With `ascending_redirect_fallback` enabled the symptom is even more confusing: the fallback then requests the parent slug (usually a folder) and surfaces its 404, e.g. `HTTP/2 404 returned for "https://api.storyblok.com/v2/cdn/stories/raeume?language=en"`.

## Fix

When `default_full_slug` is `null` and the story's `lang` is not `default`, strip the `{lang}/` prefix from `full_slug` before the slug is reused. Spaces with the Translatable Slugs app installed are unaffected (`default_full_slug` takes precedence as before).

## Testing

- New regression test: story with `default_full_slug: null`, `full_slug: "en/…"`, `lang: "en"` and a controller declaring `resolveLinks` — asserts both `bySlug()` calls receive the unprefixed slug and the controller still resolves by slug.
- Full suite green (512 tests), PHPStan clean (one baseline count adjusted for the new test).
- Verified end-to-end against a real space without Translatable Slugs: all non-default-locale pages 404 before, 200 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)